### PR TITLE
update versioned docs with version tag

### DIFF
--- a/versioned_docs/version-v0.7.0/int/quickstart/quickstart-alone.md
+++ b/versioned_docs/version-v0.7.0/int/quickstart/quickstart-alone.md
@@ -38,7 +38,7 @@ Charon is in an early alpha state and is not ready to be run on mainnet
 
    ```sh
    # Create a testnet distributed validator cluster
-   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:latest create cluster --cluster-dir=".charon" --withdrawal-address="0x000000000000000000000000000000000000dead"
+   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:v0.7.0 create cluster --cluster-dir=".charon" --withdrawal-address="0x000000000000000000000000000000000000dead"
    ```
 
 1. Start the cluster

--- a/versioned_docs/version-v0.7.0/int/quickstart/quickstart-group.md
+++ b/versioned_docs/version-v0.7.0/int/quickstart/quickstart-group.md
@@ -53,7 +53,7 @@ To create a distributed validator cluster with a group of other node operators r
 
    ```sh
    # Create an ENR private key
-   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:latest create enr
+   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:v0.7.0 create enr
    ```
 
    :::caution
@@ -78,7 +78,7 @@ To create the private keys for a distributed validator securely, a Distributed K
    # First set the ENRs of all the operators participating in DKG ceremony in .env file as CHARON_OPERATOR_ENRS
 
    # Create .charon/cluster-definition.json to participate in DKG ceremony
-   docker run --rm -v "$(pwd):/opt/charon" --env-file .env ghcr.io/obolnetwork/charon:latest create dkg
+   docker run --rm -v "$(pwd):/opt/charon" --env-file .env ghcr.io/obolnetwork/charon:v0.7.0 create dkg
    ```
 
 1. The operator that ran this command should distribute the resulting `cluster-definition.json` file to each operator.
@@ -90,7 +90,7 @@ To create the private keys for a distributed validator securely, a Distributed K
    cp cluster-definition.json .charon/
 
    # Participate in DKG ceremony, this will create .charon/cluster-lock.json, .charon/deposit-data.json and .charon/validator_keys/
-   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:latest dkg
+   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:v0.7.0 dkg
    ```
 
 ## Verifying cluster health

--- a/versioned_docs/version-v0.8.0/int/quickstart/quickstart-alone.md
+++ b/versioned_docs/version-v0.8.0/int/quickstart/quickstart-alone.md
@@ -28,7 +28,7 @@ Charon is in an early alpha state and is not ready to be run on mainnet
 
    For simplicities sake, this repo is configured to work with a remote Beacon node such as one from [Infura](https://infura.io/).
 
-   Create an Eth2 project and copy the `https` URL:
+   Create an Eth2 project and copy the `https` URL, make sure Prater is selected in dropdown of ENDPOINTS:
 
    ![Example Infura API Endpoint](/img/example-infura-details.png)
 
@@ -38,7 +38,7 @@ Charon is in an early alpha state and is not ready to be run on mainnet
 
    ```sh
    # Create a testnet distributed validator cluster
-   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:latest create cluster --cluster-dir=".charon" --withdrawal-address="0x000000000000000000000000000000000000dead"
+   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:v0.8.0 create cluster --withdrawal-address="0x000000000000000000000000000000000000dead"
    ```
 
 1. Start the cluster
@@ -53,7 +53,7 @@ Charon is in an early alpha state and is not ready to be run on mainnet
    open http://localhost:3000/d/laEp8vupp
    ```
 
-1. Activate the validator on the testnet using the original [staking launchpad](https://prater.launchpad.ethereum.org/en/overview) site with the deposit data created at `.charon/deposit-data.json`.
+1. Activate the validator on the testnet using the original [staking launchpad](https://prater.launchpad.ethereum.org/en/overview) site with the deposit data created at `.charon/cluster/deposit-data.json`.
    - If you use Mac OS, `.charon` the default output folder, does not show up on the launchpad's "Upload Deposit Data" file picker. Rectify this by pressing `Command + Shift + . ` (full stop). This should display hidden folders, allowing you to select the deposit file.
 
 Congratulations, if this all worked you are now running a distributed validator cluster on a testnet. Try turning off a single node of the four with `docker stop` and see if the validator stays online or begins missing duties, to see for yourself the fault-tolerance that can be added to proof of stake validation with this new Distributed Validator Technology.

--- a/versioned_docs/version-v0.8.0/int/quickstart/quickstart-group.md
+++ b/versioned_docs/version-v0.8.0/int/quickstart/quickstart-group.md
@@ -53,7 +53,7 @@ To create a distributed validator cluster with a group of other node operators r
 
    ```sh
    # Create an ENR private key
-   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:latest create enr
+   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:v0.8.0 create enr
    ```
 
    :::caution
@@ -78,7 +78,7 @@ To create the private keys for a distributed validator securely, a Distributed K
    # First set the ENRs of all the operators participating in DKG ceremony in .env file as CHARON_OPERATOR_ENRS
 
    # Create .charon/cluster-definition.json to participate in DKG ceremony
-   docker run --rm -v "$(pwd):/opt/charon" --env-file .env ghcr.io/obolnetwork/charon:latest create dkg
+   docker run --rm -v "$(pwd):/opt/charon" --env-file .env ghcr.io/obolnetwork/charon:v0.8.0 create dkg
    ```
 
 1. The operator that ran this command should distribute the resulting `cluster-definition.json` file to each operator.
@@ -90,7 +90,7 @@ To create the private keys for a distributed validator securely, a Distributed K
    cp cluster-definition.json .charon/
 
    # Participate in DKG ceremony, this will create .charon/cluster-lock.json, .charon/deposit-data.json and .charon/validator_keys/
-   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:latest dkg
+   docker run --rm -v "$(pwd):/opt/charon" ghcr.io/obolnetwork/charon:v0.8.0 dkg
    ```
 
 ## Verifying cluster health


### PR DESCRIPTION
Replaces latest tag with version tag in versioned docs that was missed in last PR. 
Note: This PR updates tags only for versions v0.7.0 and v0.8.0.