### PR TITLE
replace 0xdead addresses

### DIFF
--- a/docs/int/quickstart/quickstart-alone.md
+++ b/docs/int/quickstart/quickstart-alone.md
@@ -45,7 +45,7 @@ WITHDRAWAL_ADDR=<ENTER YOUR WITHDRAWAL ADDRESS HERE>
 FEE_RECIPIENT_ADDR=<ENTER YOUR FEE RECIPIENT ADDRESS HERE>
 
 # Create a distributed validator cluster
-docker run --rm -v $(pwd):/opt/charon obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="${WITHDRAWAL_ADDR}" --fee-recipient-addresses="${FEE_RECIPIENT_ADDR}" --split-existing-keys --split-keys-dir=/opt/charon/split_keys --threshold 4 --nodes 6
+docker run --rm -v $(pwd):/opt/charon obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="${WITHDRAWAL_ADDR}" --fee-recipient-addresses="${FEE_RECIPIENT_ADDR}" --nodes 6 --threshold 5
 ```
 
 This command will create a subdirectory `.charon/cluster`. In it are six folders, one for each charon node created. Each folder contains partial private keys that together make up the distributed validator described in `.charon/cluster/cluster-lock.json`. Note

--- a/docs/int/quickstart/quickstart-alone.md
+++ b/docs/int/quickstart/quickstart-alone.md
@@ -40,8 +40,12 @@ Charon is in an early alpha state and is not ready to be run on mainnet
 Run the following command:
 
 ```sh
+# Enter required validator addresses
+WITHDRAWAL_ADDR=<ENTER YOUR WITHDRAWAL ADDRESS HERE>
+FEE_RECIPIENT_ADDR=<ENTER YOUR FEE RECIPIENT ADDRESS HERE>
+
 # Create a distributed validator cluster
-docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="0x000000000000000000000000000000000000dead" --fee-recipient-addresses="0x000000000000000000000000000000000000dead" --nodes 6 --threshold 5
+docker run --rm -v $(pwd):/opt/charon obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="${WITHDRAWAL_ADDR}" --fee-recipient-addresses="${FEE_RECIPIENT_ADDR}" --split-existing-keys --split-keys-dir=/opt/charon/split_keys --threshold 4 --nodes 6
 ```
 
 This command will create a subdirectory `.charon/cluster`. In it are six folders, one for each charon node created. Each folder contains partial private keys that together make up the distributed validator described in `.charon/cluster/cluster-lock.json`. Note

--- a/docs/int/quickstart/quickstart-alone.md
+++ b/docs/int/quickstart/quickstart-alone.md
@@ -45,7 +45,7 @@ WITHDRAWAL_ADDR=<ENTER YOUR WITHDRAWAL ADDRESS HERE>
 FEE_RECIPIENT_ADDR=<ENTER YOUR FEE RECIPIENT ADDRESS HERE>
 
 # Create a distributed validator cluster
-docker run --rm -v $(pwd):/opt/charon obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="${WITHDRAWAL_ADDR}" --fee-recipient-addresses="${FEE_RECIPIENT_ADDR}" --nodes 6 --threshold 5
+docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="${WITHDRAWAL_ADDR}" --fee-recipient-addresses="${FEE_RECIPIENT_ADDR}" --nodes 6 --threshold 5
 ```
 
 This command will create a subdirectory `.charon/cluster`. In it are six folders, one for each charon node created. Each folder contains partial private keys that together make up the distributed validator described in `.charon/cluster/cluster-lock.json`. Note

--- a/versioned_docs/version-v0.14.0/int/quickstart/quickstart-alone.md
+++ b/versioned_docs/version-v0.14.0/int/quickstart/quickstart-alone.md
@@ -45,7 +45,7 @@ WITHDRAWAL_ADDR=<ENTER YOUR WITHDRAWAL ADDRESS HERE>
 FEE_RECIPIENT_ADDR=<ENTER YOUR FEE RECIPIENT ADDRESS HERE>
 
 # Create a distributed validator cluster
-docker run --rm -v $(pwd):/opt/charon obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="${WITHDRAWAL_ADDR}" --fee-recipient-addresses="${FEE_RECIPIENT_ADDR}" --split-existing-keys --split-keys-dir=/opt/charon/split_keys --threshold 4 --nodes 6
+docker run --rm -v $(pwd):/opt/charon obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="${WITHDRAWAL_ADDR}" --fee-recipient-addresses="${FEE_RECIPIENT_ADDR}" --nodes 6 --threshold 5
 ```
 
 This command will create a subdirectory `.charon/cluster`. In it are six folders, one for each charon node created. Each folder contains partial private keys that together make up the distributed validator described in `.charon/cluster/cluster-lock.json`. Note

--- a/versioned_docs/version-v0.14.0/int/quickstart/quickstart-alone.md
+++ b/versioned_docs/version-v0.14.0/int/quickstart/quickstart-alone.md
@@ -40,8 +40,12 @@ Charon is in an early alpha state and is not ready to be run on mainnet
 Run the following command:
 
 ```sh
+# Enter required validator addresses
+WITHDRAWAL_ADDR=<ENTER YOUR WITHDRAWAL ADDRESS HERE>
+FEE_RECIPIENT_ADDR=<ENTER YOUR FEE RECIPIENT ADDRESS HERE>
+
 # Create a distributed validator cluster
-docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="0x000000000000000000000000000000000000dead" --fee-recipient-addresses="0x000000000000000000000000000000000000dead" --nodes 6 --threshold 5
+docker run --rm -v $(pwd):/opt/charon obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="${WITHDRAWAL_ADDR}" --fee-recipient-addresses="${FEE_RECIPIENT_ADDR}" --split-existing-keys --split-keys-dir=/opt/charon/split_keys --threshold 4 --nodes 6
 ```
 
 This command will create a subdirectory `.charon/cluster`. In it are six folders, one for each charon node created. Each folder contains partial private keys that together make up the distributed validator described in `.charon/cluster/cluster-lock.json`. Note

--- a/versioned_docs/version-v0.14.0/int/quickstart/quickstart-alone.md
+++ b/versioned_docs/version-v0.14.0/int/quickstart/quickstart-alone.md
@@ -45,7 +45,7 @@ WITHDRAWAL_ADDR=<ENTER YOUR WITHDRAWAL ADDRESS HERE>
 FEE_RECIPIENT_ADDR=<ENTER YOUR FEE RECIPIENT ADDRESS HERE>
 
 # Create a distributed validator cluster
-docker run --rm -v $(pwd):/opt/charon obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="${WITHDRAWAL_ADDR}" --fee-recipient-addresses="${FEE_RECIPIENT_ADDR}" --nodes 6 --threshold 5
+docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v0.14.0 create cluster --name="mycluster" --withdrawal-addresses="${WITHDRAWAL_ADDR}" --fee-recipient-addresses="${FEE_RECIPIENT_ADDR}" --nodes 6 --threshold 5
 ```
 
 This command will create a subdirectory `.charon/cluster`. In it are six folders, one for each charon node created. Each folder contains partial private keys that together make up the distributed validator described in `.charon/cluster/cluster-lock.json`. Note


### PR DESCRIPTION
## Summary
Replaces 0xdead addresses with user provided address variables.

## Details
Providing 0xdead addresses in example commands can lead to users creating clusters with those addresses and if they activate those clusters in testnets/mainnet then they can get stuck with those. Rather specify users to provide their addresses in example commands.

ticket: none
