### PR TITLE
replace `docker compose restart -d` in upgrade docs.

### DIFF
--- a/docs/int/quickstart/group/quickstart-group-operator.md
+++ b/docs/int/quickstart/group/quickstart-group-operator.md
@@ -198,6 +198,7 @@ To do this, follow these steps:
 cd charon-distributed-validator-node
 
 # Stop and remove containers, networks
+# Give sufficient time for all containers to exit
 docker compose down
 
 # Pull latest changes to the repo

--- a/docs/int/quickstart/group/quickstart-group-operator.md
+++ b/docs/int/quickstart/group/quickstart-group-operator.md
@@ -197,11 +197,14 @@ To do this, follow these steps:
 # Change to the node directory
 cd charon-distributed-validator-node
 
+# Stop and remove containers, networks
+docker compose down
+
 # Pull latest changes to the repo
 git pull
 
 # Restart your DVT stack!
-docker compose restart -d
+docker compose up -d
 ```
 
 You may get a `git conflict` error like this:

--- a/docs/int/quickstart/group/quickstart-group-operator.md
+++ b/docs/int/quickstart/group/quickstart-group-operator.md
@@ -197,14 +197,10 @@ To do this, follow these steps:
 # Change to the node directory
 cd charon-distributed-validator-node
 
-# Stop and remove containers, networks
-# Give sufficient time for all containers to exit
-docker compose down
-
 # Pull latest changes to the repo
 git pull
 
-# Restart your DVT stack!
+# Create (or recreate) your DVT stack!
 docker compose up -d
 ```
 

--- a/docs/int/quickstart/quickstart-alone.md
+++ b/docs/int/quickstart/quickstart-alone.md
@@ -127,6 +127,7 @@ To do this, follow these steps:
 cd charon-distributed-validator-cluster
 
 # Stop and remove containers, networks
+# Give sufficient time for all containers to exit
 docker compose down
 
 # Pull latest changes to the repo

--- a/docs/int/quickstart/quickstart-alone.md
+++ b/docs/int/quickstart/quickstart-alone.md
@@ -126,6 +126,9 @@ To do this, follow these steps:
 # Change to the node directory
 cd charon-distributed-validator-cluster
 
+# Stop and remove containers, networks
+docker compose down
+
 # Pull latest changes to the repo
 git pull
 

--- a/docs/int/quickstart/quickstart-alone.md
+++ b/docs/int/quickstart/quickstart-alone.md
@@ -126,14 +126,10 @@ To do this, follow these steps:
 # Change to the node directory
 cd charon-distributed-validator-cluster
 
-# Stop and remove containers, networks
-# Give sufficient time for all containers to exit
-docker compose down
-
 # Pull latest changes to the repo
 git pull
 
-# Restart your DVT stack!
+# Create (or recreate) your DVT stack!
 docker compose up -d --build
 ```
 

--- a/docs/int/quickstart/quickstart-alone.md
+++ b/docs/int/quickstart/quickstart-alone.md
@@ -133,7 +133,7 @@ docker compose down
 git pull
 
 # Restart your DVT stack!
-docker compose restart -d --build
+docker compose up -d --build
 ```
 
 ## Feedback


### PR DESCRIPTION
## Summary
Replaces `docker compose restart -d` in upgrade docs.

## Details
Edits the upgrade flow:
1. cd into the repo
2. `git pull` which updates the DV stack
3. `docker compose up -d` starting the fresh stack

This ensures all containers are properly stopped, and the latest changes properly applied. If everything goes well, then start the fresh whole stack.

category: bug 
ticket:
https://github.com/ObolNetwork/obol-docs/issues/150
