### PR TITLE
add `--build` to quickstart-group as well

### DIFF
--- a/docs/int/quickstart/group/quickstart-group-operator.md
+++ b/docs/int/quickstart/group/quickstart-group-operator.md
@@ -189,9 +189,9 @@ Exiting your validator(s) can be useful in situations where you want to stop sta
 
 👉 Follow the exit guide [here](docs/int/quickstart/quickstart-exit.md)
 
-## Updating DVT stack
+## Updating DV stack
 
-It is highly recommended to upgrade your DVT stack from time to time. This ensures that your node is secure, performant, up-to-date and you don't miss important hard forks.
+It is highly recommended to upgrade your DV stack from time to time. This ensures that your node is secure, performant, up-to-date and you don't miss important hard forks.
 To do this, follow these steps:
 ```
 # Change to the node directory
@@ -200,8 +200,8 @@ cd charon-distributed-validator-node
 # Pull latest changes to the repo
 git pull
 
-# Create (or recreate) your DVT stack!
-docker compose up -d
+# Create (or recreate) your DV stack!
+docker compose up -d --build
 ```
 
 You may get a `git conflict` error like this:

--- a/docs/int/quickstart/quickstart-alone.md
+++ b/docs/int/quickstart/quickstart-alone.md
@@ -118,9 +118,9 @@ which needs a prysm beacon node to work alongside a REST based beacon node. Here
 Note: Support for prysm validator clients is in an experimental phase as prysm doesn't provide [complete support](https://github.com/prysmaticlabs/prysm/issues/11580)
 for running their validator client on a beacon node REST API. 
 
-## Updating DVT stack
+## Updating DV stack
 
-It is highly recommended to upgrade your DVT stack from time to time. This ensures that your node is secure, performant, up-to-date and you don't miss important hard forks.
+It is highly recommended to upgrade your DV stack from time to time. This ensures that your node is secure, performant, up-to-date and you don't miss important hard forks.
 To do this, follow these steps:
 ```
 # Change to the node directory
@@ -129,7 +129,7 @@ cd charon-distributed-validator-cluster
 # Pull latest changes to the repo
 git pull
 
-# Create (or recreate) your DVT stack!
+# Create (or recreate) your DV stack!
 docker compose up -d --build
 ```
 


### PR DESCRIPTION
## Summary
Adds `--build` flag to `docker compose up -d` in `quickstart-group`section. Also, renames `DVT stack` to `DVT stack`.

## Details
Having the same command for the `group` & `solo` flow is simpler and lowers the probability of people getting confused or copying the wrong command.

ticket:
https://github.com/ObolNetwork/obol-docs/issues/150
