### PR TITLE
remove terms of use link

### DIFF
--- a/docs/int/quickstart/group/index.md
+++ b/docs/int/quickstart/group/index.md
@@ -1,7 +1,7 @@
 # Run a cluster with others
 
 :::caution
-Charon is in an alpha state and should be used with caution according to its [Terms of Use](https://obol.tech/terms.pdf).
+Charon is in an alpha state and should be used with caution according to its Terms of Use.
 :::
 
 There are two user journeys when setting up a DV cluster with others. Each comes with its own quickstart

--- a/docs/int/quickstart/group/quickstart-group-leader-creator.md
+++ b/docs/int/quickstart/group/quickstart-group-leader-creator.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 # Creator & Leader Journey
 
 :::caution
-Charon is in an alpha state and should be used with caution according to its [Terms of Use](https://obol.tech/terms.pdf).
+Charon is in an alpha state and should be used with caution according to its Terms of Use.
 :::
 
 The following instructions aim to assist with the preparation of a distributed validator key generation ceremony. Select the *Leader* tab if you **will** be an operator participating in the cluster, and select the *Creator* tab if you **will NOT** be an operator in the cluster. 

--- a/docs/int/quickstart/group/quickstart-group-operator.md
+++ b/docs/int/quickstart/group/quickstart-group-operator.md
@@ -6,7 +6,7 @@ description: A node operator joins a DV cluster
 # Operator Journey
 
 :::caution
-Charon is in an alpha state and should be used with caution according to its [Terms of Use](https://obol.tech/terms.pdf).
+Charon is in an alpha state and should be used with caution according to its Terms of Use.
 :::
 
 The following instructions aim to assist a group of operators coordinating together to create a distributed validator cluster after receiving an cluster invite link from a leader or creator.

--- a/docs/int/quickstart/index.md
+++ b/docs/int/quickstart/index.md
@@ -1,7 +1,7 @@
 # Quickstart Guides
 
 :::caution
-Charon is in an alpha state and should be used with caution according to its [Terms of Use](https://obol.tech/terms.pdf).
+Charon is in an alpha state and should be used with caution according to its Terms of Use.
 :::
 
 There are two ways to run a distributed validator and each comes with its own quickstart

--- a/docs/int/quickstart/quickstart-alone.md
+++ b/docs/int/quickstart/quickstart-alone.md
@@ -6,7 +6,7 @@ description: Run all nodes in a distributed validator cluster
 # Run a cluster alone
 
 :::caution
-Charon is in an alpha state and should be used with caution according to its [Terms of Use](https://obol.tech/terms.pdf).
+Charon is in an alpha state and should be used with caution according to its Terms of Use.
 :::
 
 ## Pre-requisites

--- a/docs/int/quickstart/quickstart-builder-api.md
+++ b/docs/int/quickstart/quickstart-builder-api.md
@@ -6,7 +6,7 @@ description: Run a distributed validator cluster with the builder API (MEV-Boost
 # Run a cluster with MEV-Boost
 
 :::caution
-Charon is in an alpha state and should be used with caution according to its [Terms of Use](https://obol.tech/terms.pdf).
+Charon is in an alpha state and should be used with caution according to its Terms of Use.
 
 Charon's integration with MEV-Boost is also in an alpha state and requires a non-trivial amount of configuration to get working successfully. In future this process aims to be much more automated and seamless from the users perspective.
 :::

--- a/docs/int/quickstart/quickstart-cli.md
+++ b/docs/int/quickstart/quickstart-cli.md
@@ -6,7 +6,7 @@ description: Run one node in a multi-operator distributed validator cluster usin
 # Run a cluster using the CLI
 
 :::caution
-Charon is in an alpha state and should be used with caution according to its [Terms of Use](https://obol.tech/terms.pdf).
+Charon is in an alpha state and should be used with caution according to its Terms of Use.
 :::
 
 The following instructions aim to assist a group of operators coordinating together to create a distributed validator cluster.

--- a/docs/int/quickstart/quickstart-exit.md
+++ b/docs/int/quickstart/quickstart-exit.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 # Exit a validator
 
 :::caution
-Charon is in an alpha state and should be used with caution according to its [Terms of Use](https://obol.tech/terms.pdf).
+Charon is in an alpha state and should be used with caution according to its Terms of Use.
 :::
 
 Exiting your validator keys can be useful in situations where you want to stop staking and withdraw your staked ETH.

--- a/docs/int/quickstart/quickstart-split.md
+++ b/docs/int/quickstart/quickstart-split.md
@@ -6,7 +6,7 @@ description: Split existing validator keys
 # Split existing validator keys
 
 :::caution
-Charon is in an alpha state and should be used with caution according to its [Terms of Use](https://obol.tech/terms.pdf).
+Charon is in an alpha state and should be used with caution according to its Terms of Use.
 
 This process should only be used if you want to split an existing validator key into multiple keyshares.
 


### PR DESCRIPTION
## Summary
Removes link to obol's `Terms of Use`.

ticket: none 
