### PR TITLE
quickstart: update `builder-api` guide

### DIFF
--- a/docs/int/quickstart/advanced/adv-docker-configs.md
+++ b/docs/int/quickstart/advanced/adv-docker-configs.md
@@ -36,9 +36,3 @@ docker compose up
 ```
 docker compose -f docker-compose.yml -f docker-compose.override.yml -f compose-debug.yml up
 ```
-
-- To run [mev-boost](https://boost.flashbots.net/), run:
-
-```
-docker compose -f docker-compose.yml -f mevboost-compose.yml up
-```

--- a/docs/int/quickstart/advanced/quickstart-builder-api.md
+++ b/docs/int/quickstart/advanced/quickstart-builder-api.md
@@ -8,7 +8,7 @@ description: Run a distributed validator cluster with the builder API (MEV-Boost
 :::caution
 Charon is in an alpha state and should be used with caution according to its [Terms of Use](https://obol.tech/terms.pdf).
 
-Charon's integration with MEV-Boost is also in an alpha state and requires a non-trivial amount of configuration to get working successfully. In future this process aims to be much more automated and seamless from a user's perspective.
+Charon's integration with MEV-Boost is also in an alpha state and requires a non-trivial amount of configuration to get working successfully. In the future, this process aims to be much more automated and seamless from a user's perspective.
 :::
 
 This quickstart guide focuses on configuring the builder API for a validator and assumes you already [have a cluster up and running](docs/int/quickstart/group/index.md).
@@ -33,7 +33,7 @@ Currently, Charon with the builder API enabled, is compatible only with [Teku](h
 
 Configuring the Teku validator client with Charon follows exactly the same process as their [official guide](https://docs.teku.consensys.net/how-to/configure/use-proposer-config-file).
 
-The validator client must be set up to use the `--validators-proposer-config` [flag](https://docs.teku.consensys.net/reference/cli#validators-proposer-config) with a value equal to `http://$CHARON_ENDPOINT:3600/teku_proposer_config`
+The validator client must be set up to use the `--validators-proposer-config` [flag](https://docs.teku.consensys.net/reference/cli#validators-proposer-config) with a value equal to `http://$CHARON_ENDPOINT:3600/teku_proposer_config`.
 
 Once the flag is set up, Obol distributed validators will be able to register to the builder network, submit blinded beacon blocks and gain a share of the MEV profits.
 
@@ -43,9 +43,9 @@ For Lighthouse, we are currently waiting on the following [PR](https://github.co
 
 ### Verify Charon + Builder API is Functional
 
-Once you have Charon and your Validator Client set up you can verify the set up is functional by reviewing your proposed blocks on Etherscan testnets or on via the Relay API endpoints.
+Once you have Charon and your Validator Client set up, you can verify if your setup is functional by reviewing your proposed blocks on [beaconcha.in](https://beaconcha.in) dashboards or on via the Relay API endpoints.
 
-As an example, if my validator was the block proposer for block 17370078 on mainnet, I can review the following resources:
+As an example, if my validator was the block proposer for block `17370078` on mainnet, I can review the following resources:
 
 * [Beaconcha.in](https://beaconcha.in):
   * Consider this [Mainnet block 17370078](https://beaconcha.in/block/17370078).
@@ -59,5 +59,5 @@ As an example, if my validator was the block proposer for block 17370078 on main
   * Blocks that have not been submitted to the Relay will return an empty array `[]`.
 
 :::caution
-Note that the mainnet block in the above description is taken only as an example, and not actually proposed by a distributed validator.
+Note that the mainnet block in the above description is taken only for representation, and not actually proposed by a distributed validator.
 :::caution

--- a/docs/int/quickstart/advanced/quickstart-builder-api.md
+++ b/docs/int/quickstart/advanced/quickstart-builder-api.md
@@ -11,25 +11,41 @@ Charon is in an alpha state and should be used with caution according to its [Te
 Charon's integration with MEV-Boost is also in an alpha state and requires a non-trivial amount of configuration to get working successfully. In the future, this process aims to be much more automated and seamless from a user's perspective.
 :::
 
-This quickstart guide focuses on configuring the builder API for a validator and assumes you already [have a cluster up and running](docs/int/quickstart/group/index.md).
+This quickstart guide focuses on configuring the builder API for Charon and supported Validator clients.
 
 ## Getting started with Charon & the Builder API
 
-Running a distributed validator cluster with the builder API enabled will give the validators in the cluster access to the builder network. This builder network is a network of "Block Builders" who work with MEV searchers to produce the most valuable blocks a validator can propose. [MEV-Boost](https://boost.flashbots.net/) is a product from flashbots that enables you to ask multiple block relays (who communicate with the "Block Builders") for blocks to propose. The block that pays the largest reward to the validator will be signed and returned to the relay for broadcasting to the wider network. The end result for the validator is generally an increased APY as they receive some share of the MEV.
+Running a distributed validator cluster with the builder API enabled will give the validators in the cluster access to the builder network. This builder network is a network of "Block Builders"
+who work with MEV searchers to produce the most valuable blocks a validator can propose.
 
-## Configuring Charon
+[MEV-Boost](https://boost.flashbots.net/) is one such product from flashbots that enables you to ask multiple
+block relays (who communicate with the "Block Builders") for blocks to propose. The block that pays the largest reward to the validator will be signed and returned to the relay for broadcasting to the wider 
+network. The end result for the validator is generally an increased APY as they receive some share of the MEV.
 
-To configure Charon to use the builder API you simply need to add one flag to the `charon run` command.
+## Run MEV Boost
+
+Currently, we don't support [mev-boost](https://boost.flashbots.net/) if you are running your charon cluster using [this repo](https://github.com/ObolNetwork/charon-distributed-validator-node) since the repo 
+uses lodestar validator client which is not `builder API` compatible with Charon.
+
+We are working on a solution that enables the builder API feature irrespective of the choice of the Validator Client.
+
+## Builder API
+
+If you want to configure Charon and supported Validator clients to support the builder API feature, you can do that as well.
+
+Currently, Charon with the builder API enabled, is compatible only with [Teku](https://github.com/ConsenSys/teku). Work is underway [to support](https://dvt.obol.tech/) all validator client implementations in a mev-enabled distributed validator cluster seamlessly.
+
+### Charon
+
+Charon supports builder API with the `--builder-api` flag. To use builder API, one simply needs to add this flag to the `charon run` command:
 
 ```
 charon run --builder-api
 ```
 
-## Configuring Validator Clients
+### Validator Clients
 
-Currently, Charon with the builder API enabled, is compatible only with [Teku](https://github.com/ConsenSys/teku) and requires a decent amount of manual configuration. Work is underway [to support](https://dvt.obol.tech/) all validator client implementations in a mev-enabled distributed validator cluster seamlessly.
-
-### Teku Validator Client
+#### Teku Validator Client
 
 Configuring the Teku validator client with Charon follows exactly the same process as their [official guide](https://docs.teku.consensys.net/how-to/configure/use-proposer-config-file).
 
@@ -37,29 +53,23 @@ The validator client must be set up to use the `--validators-proposer-config` [f
 
 Once the flag is set up, Obol distributed validators will be able to register to the builder network, submit blinded beacon blocks and gain a share of the MEV profits.
 
-### Lighthouse Validator Client
+#### Lighthouse Validator Client
 
 For Lighthouse, we are currently waiting on the following [PR](https://github.com/sigp/lighthouse/pull/4306) to be merged into their unstable branch to enable compatability, please review the PR's status.
 
-## Run MEV Boost
+## Verify MEV Boost is functional
 
-If you want to run [mev-boost](https://boost.flashbots.net/) and if you are already running the [cluster](docs/int/quickstart/group/index.md), you can follow these steps:
+Once you have executed the above steps, you can verify if your setup is functional by reviewing your proposed blocks on [beaconcha.in](https://beaconcha.in) dashboards or via the Relay API endpoints.
 
-- Set `BUILDER_API_ENABLED=true` in `.env`
-- Restart your stack
-```
-docker compose -f docker-compose.yml -f mevboost-compose.yml up
-```
-
-### Verify Charon + Builder API is Functional
-
-Once you have Charon and your Validator Client set up, you can verify if your setup is functional by reviewing your proposed blocks on [beaconcha.in](https://beaconcha.in) dashboards or via the Relay API endpoints.
+:::caution
+Note that the mainnet block in the below description is taken only for representation, and not actually proposed by a distributed validator.
+:::caution
 
 As an example, if my validator was the block proposer for block `17370078` on mainnet, I can review the following resources:
 
 * [Beaconcha.in](https://beaconcha.in):
   * Consider this [Mainnet block 17370078](https://beaconcha.in/block/17370078).
-  * If we check the `Block Extra Data` field under `Execution Payload`, we will see the tag `Illuminate Dmocratize Dstribute` (Hex:`0x496c6c756d696e61746520446d6f63726174697a6520447374726962757465`). 
+  * If we check the `Block Extra Data` field under `Execution Payload`, we will see the tag `Illuminate Dmocratize Dstribute` (Hex:`0x496c6c756d696e61746520446d6f63726174697a6520447374726962757465`).
   * Relays will generally add a tag to the block. Since this block was submitted via the Flashbots Relay, as a result it has the tag.
   * All mainnet flashbots blocks have this tag `Illuminate Dmocratize Dstribute`.
 * [Relay API](https://flashbots.github.io/relay-specs/):
@@ -67,7 +77,3 @@ As an example, if my validator was the block proposer for block `17370078` on ma
   * You can add a query argument of `block_number` to this call to see if a block was submitted via that Relay.
   * [Here](https://boost-relay.flashbots.net/relay/v1/data/bidtraces/proposer_payload_delivered?block_number=17370078) is the query for the example block 17370078.
   * Blocks that have not been submitted to the Relay will return an empty array `[]`.
-
-:::caution
-Note that the mainnet block in the above description is taken only for representation, and not actually proposed by a distributed validator.
-:::caution

--- a/docs/int/quickstart/advanced/quickstart-builder-api.md
+++ b/docs/int/quickstart/advanced/quickstart-builder-api.md
@@ -41,6 +41,16 @@ Once the flag is set up, Obol distributed validators will be able to register to
 
 For Lighthouse, we are currently waiting on the following [PR](https://github.com/sigp/lighthouse/pull/4306) to be merged into their unstable branch to enable compatability, please review the PR's status.
 
+## Run MEV Boost
+
+If you want to run [mev-boost](https://boost.flashbots.net/) and if you are already running the [cluster](docs/int/quickstart/group/index.md), you can follow these steps:
+
+- Set `BUILDER_API_ENABLED=true` in `.env`
+- Restart your stack
+```
+docker compose -f docker-compose.yml -f mevboost-compose.yml up
+```
+
 ### Verify Charon + Builder API is Functional
 
 Once you have Charon and your Validator Client set up, you can verify if your setup is functional by reviewing your proposed blocks on [beaconcha.in](https://beaconcha.in) dashboards or via the Relay API endpoints.

--- a/docs/int/quickstart/advanced/quickstart-builder-api.md
+++ b/docs/int/quickstart/advanced/quickstart-builder-api.md
@@ -27,79 +27,37 @@ charon run --builder-api
 
 ## Configuring Validator Clients
 
-Currently Charon with the builder API enabled is comaptible with two validator clients, Teku (develop branch) & Lighthouse (unstable branch) and requires a decent amount of manual configuration. Work is underway [to support](https://github.com/ObolNetwork/charon#project-status) all validator client implementations in an mev-enabled distributed validator cluster seamlessly.
+Currently, Charon with the builder API enabled, is compatible only with [Teku](https://github.com/ConsenSys/teku) and requires a decent amount of manual configuration. Work is underway [to support](https://dvt.obol.tech/) all validator client implementations in a mev-enabled distributed validator cluster seamlessly.
 
 ### Teku Validator Client
 
-For now you must use the [develop branch / container image](https://hub.docker.com/r/consensys/teku/tags) of Teku to have access to the changes that enable compatibility.
+Configuring the Teku validator client with Charon follows exactly the same process as their [official guide](https://docs.teku.consensys.net/how-to/configure/use-proposer-config-file).
 
-Configuring the Teku validator client with Charon follows exactly the same process as their [official guide](https://hackmd.io/@StefanBratanov/BkMlo1RO9) with 2 further conditions.
+The validator client must be set up to use the `--validators-proposer-config` [flag](https://docs.teku.consensys.net/reference/cli#validators-proposer-config) with a value equal to `http://$CHARON_ENDPOINT:3600/teku_proposer_config`
 
-- First the validator client must be set up to use the `proposerConfig.json` structure. This involves including the [`--validators-proposer-config`](https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#validators-proposer-config) flag on the validator client.
-- Second the `--validators-proposer-config` flag must be equal to `http://$CHARON_ENDPOINT:3600/teku_proposer_config`
-
-With these 2 conditions in places Charon validators will be able to register to the builder network, submit blinded block and gain a share of the MEV profits.
+Once the flag is set up, Obol distributed validators will be able to register to the builder network, submit blinded beacon blocks and gain a share of the MEV profits.
 
 ### Lighthouse Validator Client
 
-For Lighthouse we are currently waiting on the following [PR](https://github.com/sigp/lighthouse/pull/3445) to be merged into their unstable branch to enable compatability, please review the PR's status.
-
-If the PR has been merged Lighthouse can be used with Charon. You must use the [unstable branch / container image](https://hub.docker.com/r/sigp/lighthouse/tags) to have access to the changes that enable compatibility.
-
-Configuring the Lightouse validator client with Charon follows exactly the same process as their [official guide](https://lighthouse-book.sigmaprime.io/builders.html) with some additional conditions.
-
-- The validator client must be set up to use a custom [validator_definitions.yml](https://lighthouse-book.sigmaprime.io/validator-management.html).
-- The flag `--builder-registration-timestamp-override` must be set and the assigned value must be the same across all validator clients.
-- The custom validator_definitions.yml must be placed in the `--validators-dir` of lighthouse.
-- The custom validator_definitions.yml must follow the structure below, where `voting_public_key` is the pubkey share on the validator client and `builder_pubkey_override` is the associated aggregate pubkey the network will find. You can find these pubkey share to aggregate pubkey mappings in the `cluster-lock.json` file created during the DKG process.
-
-```yaml
----
-- enabled: true
-  voting_public_key: 0xa6469d287f26ecb36049b79b408e25738a0e159980f32fb659174416b9e0e8f7f8ecc55d01a54528c16c138bb1201eaf
-  type: local_keystore
-  voting_keystore_path: /data/lighthouse/validator_keys/keystore-0.json
-  voting_keystore_password_path: /data/lighthouse/validator_keys/keystore-0.txt
-  suggested_fee_recipient: 0x000000000000000000000000dec0ded0b0115ace
-  gas_limit: 30000000
-  builder_proposals: true
-  builder_pubkey_override: 0xa878c8ec402799536f0b94967e578fdbcd84828f564d604f0db491979438357b797491399be1f22de8a44673f14c087e
-- enabled: true
-  voting_public_key: 0x821ec75ca12057b484906a492ea3448387065a9466c348e81e72f23139e7abdf2f38854cc9dea8d51ca615cbe15f9d2c
-  type: local_keystore
-  voting_keystore_path: /data/lighthouse/validator_keys/keystore-1.json
-  voting_keystore_password_path: /data/lighthouse/validator_keys/keystore-1.txt
-  suggested_fee_recipient: 0x000000000000000000000000dec0ded0b0115ace
-  gas_limit: 30000000
-  builder_proposals: true
-  builder_pubkey_override: 0x93e600b9836acda0e7781dc50268478b13c2a73fa470728b8e7fd06f31d62ddbdf831cbf5b7a828276a2218f2016a2fa
-- enabled: true
-  voting_public_key: 0xa5581286066c5251fbc7c2a6685a9ccce951ccb9b6e449a3f90c33c971dac9b297f9a7a3f9394c8a43822ff0f2cfded1
-  type: local_keystore
-  voting_keystore_path: /data/lighthouse/validator_keys/keystore-2.json
-  voting_keystore_password_path: /data/lighthouse/validator_keys/keystore-2.txt
-  suggested_fee_recipient: 0x000000000000000000000000dec0ded0b0115ace
-  gas_limit: 30000000
-  builder_proposals: true
-  builder_pubkey_override: 0x8793b522c8197c047b95b6f4b3c7fd1582a2466ff96eb274ee51fc699c99cbdfeb41cf576bbbbdecf2454527083edf34
-```
-
-Note the pubkey shares in the `cluster-lock.json` are base64 encoded and decode to hex. Below is a decoding example for the first `voting_public_key` seen above.
-
-```sh
-echo pkadKH8m7LNgSbebQI4lc4oOFZmA8y+2WRdEFrng6Pf47MVdAaVFKMFsE4uxIB6v | base64 -d | hexdump -v -e '/1 "%02x" ' | (echo -n 0x && cat)
-
--> 0xa6469d287f26ecb36049b79b408e25738a0e159980f32fb659174416b9e0e8f7f8ecc55d01a54528c16c138bb1201eaf
-```
-
-Feel free to update the `voting_keystore_path`, `suggested_fee_recipient` etc. to whatever you have set up for your environment. Note that there either needs to be a different `validator_definitions.yml` on each distributed validator based on the keys it holds or a single `validator_definitions.yml` file can be used but you must ensure no collisions on the `voting_keystore_path` & `voting_keystore_password_path`.
+For Lighthouse, we are currently waiting on the following [PR](https://github.com/sigp/lighthouse/pull/4306) to be merged into their unstable branch to enable compatability, please review the PR's status.
 
 ### Verify Charon + Builder API is Functional
 
 Once you have Charon and your Validator Client set up you can verify the set up is functional by reviewing your proposed blocks on Etherscan testnets or on via the Relay API endpoints.
 
-As an example if my validator was the block proposer for block 12853375 on Ropsten I can review the following resources.
+As an example, if my validator was the block proposer for block 17370078 on mainnet, I can review the following resources:
 
-[Etherscan Ropsten Block 12853375](https://ropsten.etherscan.io/block/12853375), if we check the `Extra Data` field on this page we will see the tag `Flashbots flashblock (Hex:0x466c617368626f747320666c617368626c6f636b)`. Relays will generally add a tag to the block, this block was submitted via the Flashbots Relay and as a result it has the tag: `Flashbots flashblock`.
+* [Beaconcha.in](https://beaconcha.in):
+  * Consider this [Mainnet block 17370078](https://beaconcha.in/block/17370078).
+  * If we check the `Block Extra Data` field under `Execution Payload`, we will see the tag `Illuminate Dmocratize Dstribute` (Hex:`0x496c6c756d696e61746520446d6f63726174697a6520447374726962757465`). 
+  * Relays will generally add a tag to the block. Since this block was submitted via the Flashbots Relay, as a result it has the tag.
+  * All mainnet flashbots blocks have this tag `Illuminate Dmocratize Dstribute`.
+* [Relay API](https://flashbots.github.io/relay-specs/):
+  * If you navigate to the `Data API` section on the Relay API page, you will see an endpoint labeled `/relay/v1/data/bidtraces/proposer_payload_delivered`.
+  * You can add a query argument of `block_number` to this call to see if a block was submitted via that Relay.
+  * [Here](https://boost-relay.flashbots.net/relay/v1/data/bidtraces/proposer_payload_delivered?block_number=17370078) is the query for the example block 17370078.
+  * Blocks that have not been submitted to the Relay will return an empty array `[]`.
 
-[Relay Data API](https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5), if you navigate to the `Data API` section on the Relay Data API you will see an endpoint labeled `proposerPayloadsDelivered`. You are able to add a query argument of `block_number` to this call to see if a block was submitted via that Relay. [Here](https://builder-relay-ropsten.flashbots.net/relay/v1/data/bidtraces/proposer_payload_delivered?block_number=12853375) is the query for the example block 12853375. Blocks that have not been submitted to the Relay will return an empty array `[]`.
+:::caution
+Note that the mainnet block in the above description is taken only as an example, and not actually proposed by a distributed validator.
+:::caution

--- a/docs/int/quickstart/advanced/quickstart-builder-api.md
+++ b/docs/int/quickstart/advanced/quickstart-builder-api.md
@@ -47,7 +47,7 @@ charon run --builder-api
 
 #### Teku Validator Client
 
-Configuring the Teku validator client with Charon follows exactly the same process as their [official guide](https://docs.teku.consensys.net/how-to/configure/use-proposer-config-file).
+Configuring the Teku validator client with Charon can be done by following the same process outlined in the [Teku official guide](https://docs.teku.consensys.net/how-to/configure/use-proposer-config-file).
 
 The validator client must be set up to use the `--validators-proposer-config` [flag](https://docs.teku.consensys.net/reference/cli#validators-proposer-config) with a value equal to `http://$CHARON_ENDPOINT:3600/teku_proposer_config`.
 

--- a/docs/int/quickstart/advanced/quickstart-builder-api.md
+++ b/docs/int/quickstart/advanced/quickstart-builder-api.md
@@ -43,7 +43,7 @@ For Lighthouse, we are currently waiting on the following [PR](https://github.co
 
 ### Verify Charon + Builder API is Functional
 
-Once you have Charon and your Validator Client set up, you can verify if your setup is functional by reviewing your proposed blocks on [beaconcha.in](https://beaconcha.in) dashboards or on via the Relay API endpoints.
+Once you have Charon and your Validator Client set up, you can verify if your setup is functional by reviewing your proposed blocks on [beaconcha.in](https://beaconcha.in) dashboards or via the Relay API endpoints.
 
 As an example, if my validator was the block proposer for block `17370078` on mainnet, I can review the following resources:
 

--- a/docs/int/quickstart/quickstart-mainnet.md
+++ b/docs/int/quickstart/quickstart-mainnet.md
@@ -98,7 +98,7 @@ CHARON_BEACON_NODE_ENDPOINTS=<YOUR_REMOTE_MAINNET_BEACON_NODE_URL>
 If you are running your mainnet DV node with `mev-boost`, you need to uncomment and set the `MEVBOOST_RELAYS` variable in the `.env` file
 ```
 ...
-# MEV-Boost docker container image version, e.g. `latest` or `v1.4.0`.
+# MEV-Boost docker container image version, e.g. `latest` or `v1.5.0`.
 #MEVBOOST_VERSION=
 MEVBOOST_RELAYS=https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com
 ...

--- a/docs/int/quickstart/quickstart-mainnet.md
+++ b/docs/int/quickstart/quickstart-mainnet.md
@@ -93,18 +93,6 @@ CHARON_BEACON_NODE_ENDPOINTS=<YOUR_REMOTE_MAINNET_BEACON_NODE_URL>
 ...
 ```
 
-#### Mainnet node with mev-boost
-
-If you are running your mainnet DV node with `mev-boost`, you need to uncomment and set the `MEVBOOST_RELAYS` variable in the `.env` file
-```
-...
-# MEV-Boost docker container image version, e.g. `latest` or `v1.5.0`.
-#MEVBOOST_VERSION=
-MEVBOOST_RELAYS=https://0x9000009807ed12c1f08bf4e81c6da3ba8e3fc3d953898ce0102433094e5f22f21102ec057841fcb81978ed1ea0fa8246@builder-relay-mainnet.blocknative.com
-...
-```
-You can also use the [flashbots relay](https://boost-relay.flashbots.net/).
-
 #### Exit a mainnet distributed validator
 
 If you want to exit your mainnet validator, you need to uncomment and set the `EXIT_EPOCH` variable in the `.env` file


### PR DESCRIPTION
## Summary

Updates `builder-api` quickstart guide.

## Details

* Fix outdated docs and broken links
* Remove section for lighthouse as it is not supported
* Add new example for mainnet replacing deprecated ropsten example

ticket: https://github.com/ObolNetwork/charon-distributed-validator-node/issues/154
