### PR TITLE
remove teku from prometheus config

### DIFF
--- a/docs/int/quickstart/advanced/monitoring-credentials.md
+++ b/docs/int/quickstart/advanced/monitoring-credentials.md
@@ -31,9 +31,9 @@ scrape_configs:
   - job_name: 'charon'
     static_configs:
       - targets: ['charon:3620']
-  - job_name: 'teku'
+  - job_name: "lodestar"
     static_configs:
-      - targets: ['teku:8008']
+      - targets: [ "lodestar:5064" ]
   - job_name: 'node-exporter'
     static_configs:
       - targets: ['node-exporter:9100']


### PR DESCRIPTION
## Summary

Removes teku from prometheus config and replaces with lodestar.

This is in line with changes in this PR - https://github.com/ObolNetwork/charon-distributed-validator-node/pull/187.

## Details

None.

ticket: none 
