### PR TITLE
Remove EV audit/review from overview

### DIFF
--- a/docs/sec/overview.md
+++ b/docs/sec/overview.md
@@ -48,4 +48,4 @@ The Obol Network consists of four core public goods:
 ## List of Security Audits
 
 ### 2023
-Ethereal Ventures did the initial security readiness review for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).
+The completed audits reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).

--- a/docs/sec/overview.md
+++ b/docs/sec/overview.md
@@ -48,4 +48,4 @@ The Obol Network consists of four core public goods:
 ## List of Security Audits
 
 ### 2023
-Ethereal Ventures did the initial security audit for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).
+Ethereal Ventures did the initial security readiness review for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).

--- a/versioned_docs/version-v0.14.0/sec/overview.md
+++ b/versioned_docs/version-v0.14.0/sec/overview.md
@@ -50,4 +50,4 @@ The Obol Network consists of four core public goods:
 ## List of Security Audits
 
 ### 2023
-Ethereal Ventures did the initial security audit for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).
+Ethereal Ventures did the initial security readiness review for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).

--- a/versioned_docs/version-v0.14.0/sec/overview.md
+++ b/versioned_docs/version-v0.14.0/sec/overview.md
@@ -50,4 +50,4 @@ The Obol Network consists of four core public goods:
 ## List of Security Audits
 
 ### 2023
-Ethereal Ventures did the initial security readiness review for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).
+The completed audits reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).

--- a/versioned_docs/version-v0.14.4/sec/overview.md
+++ b/versioned_docs/version-v0.14.4/sec/overview.md
@@ -49,4 +49,4 @@ The Obol Network consists of four core public goods:
 ## List of Security Audits
 
 ### 2023
-Ethereal Ventures did the initial security audit for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).
+Ethereal Ventures did the initial security readiness review for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).

--- a/versioned_docs/version-v0.14.4/sec/overview.md
+++ b/versioned_docs/version-v0.14.4/sec/overview.md
@@ -49,4 +49,4 @@ The Obol Network consists of four core public goods:
 ## List of Security Audits
 
 ### 2023
-Ethereal Ventures did the initial security readiness review for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).
+The completed audits reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).

--- a/versioned_docs/version-v0.15.0/sec/overview.md
+++ b/versioned_docs/version-v0.15.0/sec/overview.md
@@ -49,4 +49,4 @@ The Obol Network consists of four core public goods:
 ## List of Security Audits
 
 ### 2023
-Ethereal Ventures did the initial security audit for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).
+Ethereal Ventures did the initial security readiness review for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).

--- a/versioned_docs/version-v0.15.0/sec/overview.md
+++ b/versioned_docs/version-v0.15.0/sec/overview.md
@@ -49,4 +49,4 @@ The Obol Network consists of four core public goods:
 ## List of Security Audits
 
 ### 2023
-Ethereal Ventures did the initial security readiness review for Obol's software development processes, vulnerability disclosure and escalation procedures, and the key personnel risk. The audits completed reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).
+The completed audits reports are linked [here](https://github.com/ObolNetwork/obol-security/tree/main/audits).


### PR DESCRIPTION
## Summary
We need to remove the references to the EV audit until get Alex's approval
 
## Details
Update the security docs and overview pages for current and older versions

ticket:
<!--link to a GitHub issue (or 'none' if PR is trivial)-->
