### PR TITLE
updated private key backup caution message

### DIFF
--- a/docs/int/quickstart/group/quickstart-group-leader-creator.md
+++ b/docs/int/quickstart/group/quickstart-group-leader-creator.md
@@ -63,7 +63,7 @@ You should expect to see a console output like
 If instead of being shown your `enr` you see an error saying `permission denied` then you may need to [update docker permissions](/docs/int/faq/errors#docker-permission-denied-error) to allow the command to run successfully.
 
 :::caution
-Please make sure to create a backup of the private key at `.charon/charon-enr-private-key`. Be careful not to commit it to git! **If you lose this file you won't be able to take part in the DKG ceremony and start the DV cluster successfully.**
+Ensure you create a backup of the private key stored in the '.charon' folder, specifically at '.charon/charon-enr-private-key'. This is the file used to generate your private key. Be careful not to commit it to git! **If you lose this file you won't be able to take part in the DKG ceremony and start the DV cluster successfully.**
 :::
 
   </TabItem>


### PR DESCRIPTION
## Summary
Updated the private key backup caution box, so that the text is more clear on what exactly should be backed up 

ticket:
https://github.com/ObolNetwork/obol-docs/issues/283
