### PR TITLE
adding a link to the new Quantstamp Charon audit

### DIFF
--- a/docs/sec/overview.md
+++ b/docs/sec/overview.md
@@ -25,7 +25,7 @@ The completed audits reports are linked [here](https://github.com/ObolNetwork/ob
 
 - A [solidity audit](./smart_contract_audit) of the Obol Splits contracts by [Zach Obront](https://zachobront.com/).
 
-- A second audit of Charon is planned for Q4 2023.
+- A 2nd [audit of Charon](https://obol.tech/reports/Quantstamp_charon_audit_2023_Q4.pdf) by QuantStamp in Q4 of 2023.
 
 ## Security focused documents
 


### PR DESCRIPTION
## Summary
adding a link to the new Quantstamp Charon audit, which is hosted on obol.tech at https://obol.tech/reports/Quantstamp_charon_audit_2023_Q4.pdf
