### PR TITLE
adding the git clone step in the launchpad tab of the quickstart alone

### DIFF
--- a/docs/start/quickstart_alone.md
+++ b/docs/start/quickstart_alone.md
@@ -30,6 +30,16 @@ The private key shares can be created centrally and distributed securely to each
 <Tabs groupId="Launchpad-other">
   <TabItem value="Launchpad" label="Launchpad" default>
 Go to the the <a href="/docs/dvl/intro#dv-launchpad-links">DV Launchpad</a> and select <code>Create a distributed validator alone</code>. Follow the steps to configure your DV cluster. The Launchpad will give you a docker command, which you should run in your terminal.
+<br/><br/>
+Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">Quickstart Alone</a> demo repo and `cd` into the directory.
+
+  ```bash
+  # Clone the repo
+  git clone https://github.com/ObolNetwork/charon-distributed-validator-cluster.git
+
+  # Change directory
+  cd charon-distributed-validator-cluster/
+  ```
   </TabItem>
   <TabItem value="CLI" label="CLI">
     

--- a/docs/start/quickstart_alone.md
+++ b/docs/start/quickstart_alone.md
@@ -29,9 +29,7 @@ The private key shares can be created centrally and distributed securely to each
 
 <Tabs groupId="Launchpad-other">
   <TabItem value="Launchpad" label="Launchpad" default>
-Go to the the <a href="/docs/dvl/intro#dv-launchpad-links">DV Launchpad</a> and select <code>Create a distributed validator alone</code>. Follow the steps to configure your DV cluster. The Launchpad will give you a docker command, which you should run in your terminal.
-<br/><br/>
-Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">Quickstart Alone</a> demo repo and `cd` into the directory.
+    Go to the the <a href="/docs/dvl/intro#dv-launchpad-links">DV Launchpad</a> and select <code>Create a distributed validator alone</code>. Follow the steps to configure your DV cluster. The Launchpad will give you a docker command to create your cluster. <br/>Before you run the command, checkout the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">Quickstart Alone</a> demo repo and <code>cd</code> into the directory.
 
   ```bash
   # Clone the repo
@@ -39,12 +37,15 @@ Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-c
 
   # Change directory
   cd charon-distributed-validator-cluster/
+
+  # Run the command provided in the DV Launchpad "Create a cluster alone" flow
+  docker run -u $(id -u):$(id -g) --rm -v "$(pwd)/:/opt/charon" obolnetwork/charon:v0.19.1 create cluster --definition-file=...
   ```
   </TabItem>
 
   <TabItem value="CLI" label="CLI">
-1. Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">Quickstart Alone</a> demo repo and `cd` into the directory.
 
+1. Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster">Quickstart Alone</a> demo repo and <code>cd</code> into the directory.
   ```bash
   # Clone the repo
   git clone https://github.com/ObolNetwork/charon-distributed-validator-cluster.git
@@ -52,29 +53,29 @@ Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-c
   # Change directory
   cd charon-distributed-validator-cluster/
   ```
+2. Run the cluster creation command, setting required flag values.
 
-2. Prepare the environment variables
+  Run the below command to create the validator private key shares and cluster artifacts locally, replacing the example values for `nodes`, `network`, `num-validators`, `fee-recipient-addresses`,  and `withdrawal-addresses`.
+  Check the [Charon CLI reference](../charon/charon-cli-reference.md#create-a-full-cluster-locally) for additional, optional flags to set.
+  ```bash
+    docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v0.19.1 create cluster --nodes=4 --network=holesky --num-validators=1 --name="Quickstart Guide Cluster" --cluster-dir="cluster" --fee-recipient-addresses=0x000000000000000000000000000000000000dead --withdrawal-addresses=0x000000000000000000000000000000000000dead
+  ```
 
-`.env.sample` is a sample environment file that allows overriding default configuration defined in `docker-compose.yml`. Setup the desired settings for the DV by uncommenting lines and setting values. Once you have set the values you wish to use, make a copy of this file called `.env`.
+:::tip
+If you would like your cluster to appear on the [DV Launchpad](../dvl/intro), add the `--publish` flag to the command.
+:::
 
-```bash
-# Copy the sample environment variables
-cp .env.sample .env
-```
-
-3. Run the cluster creation command, setting required flag values
-
-Run the below command to create all the key shares and cluster artifacts locally, manually setting the values of flags “nodes”, “network”, “num-validators”, “fee-recipient-addresses”,  and “withdrawal-addresses”. 
-Check the [Charon CLI reference](../charon/charon-cli-reference.md#create-a-full-cluster-locally) for additional, optional flags to set.
-
-<pre>
-  docker run --rm -v "$(pwd):/opt/charon" --env-file .env obolnetwork/charon:v0.19.1 create cluster --nodes=4 --network=holesky --num-validators=1 --fee-recipient-addresses=[ENTER YOUR FEE RECIPIENT ADDRESS HERE] --withdrawal-addresses=[ENTER YOUR WITHDRAWAL ADDRESS HERE]
-</pre>
   </TabItem>
 </Tabs>
 <br />
 
-After the command is run, you should have multiple folders within `./cluster/`, one for each node created. Backup the `./cluster/` folder, then move on to deploying the cluster.
+After the `create cluster` command is run, you should have multiple subfolders within the newly created `./cluster/` folder, one for each node created.
+
+**Backup the `./cluster/` folder, then move on to deploying the cluster.**
+
+:::info
+Make sure your backup is secure and private, someone with access to these files could get the validators slashed.
+:::
 
 ## Step 2: Deploy and start the nodes
 

--- a/docs/start/quickstart_alone.md
+++ b/docs/start/quickstart_alone.md
@@ -41,9 +41,8 @@ Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-c
   cd charon-distributed-validator-cluster/
   ```
   </TabItem>
+
   <TabItem value="CLI" label="CLI">
-    
-    
 1. Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">Quickstart Alone</a> demo repo and `cd` into the directory.
 
   ```bash
@@ -56,36 +55,26 @@ Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-c
 
 2. Prepare the environment variables
 
-`.env.sample` is a sample environment file that allows overriding default configuration defined in `docker-compose.yml`. Setup the desired settings for the DV, including the network you wish to operate on. Check the [Charon CLI reference](../charon/charon-cli-reference.md) for additional optional flags to set.
-
-<pre>
-  <code>
-  WITHDRAWAL_ADDR=[ENTER YOUR WITHDRAWAL ADDRESS HERE]
-  <br/>
-  FEE_RECIPIENT_ADDR=[ENTER YOUR FEE RECIPIENT ADDRESS HERE]
-  <br/>
-  NETWORK="holesky"
-  </code>
-</pre>
-
- 
-3. Once you have set the values you wish to use. Make a copy of this file called `.env`.
+`.env.sample` is a sample environment file that allows overriding default configuration defined in `docker-compose.yml`. Setup the desired settings for the DV by uncommenting lines and setting values. Once you have set the values you wish to use, make a copy of this file called `.env`.
 
 ```bash
 # Copy the sample environment variables
 cp .env.sample .env
 ```
 
-4.  Then, run this command to create all the key shares and cluster artifacts locally:
+3. Run the cluster creation command, setting required flag values
+
+Run the below command to create all the key shares and cluster artifacts locally, manually setting the values of flags “nodes”, “network”, “num-validators”, “fee-recipient-addresses”,  and “withdrawal-addresses”. 
+Check the [Charon CLI reference](../charon/charon-cli-reference.md#create-a-full-cluster-locally) for additional, optional flags to set.
 
 <pre>
-  docker run --rm -v "$(pwd):/opt/charon" --env-file .env obolnetwork/charon:v0.19.0 create cluster 
+  docker run --rm -v "$(pwd):/opt/charon" --env-file .env obolnetwork/charon:v0.19.1 create cluster --nodes=4 --network=holesky --num-validators=1 --fee-recipient-addresses=[ENTER YOUR FEE RECIPIENT ADDRESS HERE] --withdrawal-addresses=[ENTER YOUR WITHDRAWAL ADDRESS HERE]
 </pre>
   </TabItem>
 </Tabs>
 <br />
 
-You should now have multiple folders within `./cluster/`, one for each node created. Backup the `./cluster/` folder, then move on to deploying the cluster physically.
+After the command is run, you should have multiple folders within `./cluster/`, one for each node created. Backup the `./cluster/` folder, then move on to deploying the cluster.
 
 ## Step 2: Deploy and start the nodes
 

--- a/versioned_docs/version-v0.19.1/start/quickstart_alone.md
+++ b/versioned_docs/version-v0.19.1/start/quickstart_alone.md
@@ -30,6 +30,17 @@ The private key shares can be created centrally and distributed securely to each
 <Tabs groupId="Launchpad-other">
   <TabItem value="Launchpad" label="Launchpad" default>
 Go to the the <a href="/docs/dvl/intro#dv-launchpad-links">DV Launchpad</a> and select <code>Create a distributed validator alone</code>. Follow the steps to configure your DV cluster. The Launchpad will give you a docker command, which you should run in your terminal.
+
+<br/><br/>
+Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">Quickstart Alone</a> demo repo and `cd` into the directory.
+
+  ```bash
+  # Clone the repo
+  git clone https://github.com/ObolNetwork/charon-distributed-validator-cluster.git
+
+  # Change directory
+  cd charon-distributed-validator-cluster/
+  ```
   </TabItem>
   <TabItem value="CLI" label="CLI">
     

--- a/versioned_docs/version-v0.19.1/start/quickstart_alone.md
+++ b/versioned_docs/version-v0.19.1/start/quickstart_alone.md
@@ -43,8 +43,6 @@ Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-c
   ```
   </TabItem>
   <TabItem value="CLI" label="CLI">
-    
-    
 1. Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">Quickstart Alone</a> demo repo and `cd` into the directory.
 
   ```bash
@@ -57,36 +55,26 @@ Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-c
 
 2. Prepare the environment variables
 
-`.env.sample` is a sample environment file that allows overriding default configuration defined in `docker-compose.yml`. Setup the desired settings for the DV, including the network you wish to operate on. Check the [Charon CLI reference](../charon/charon-cli-reference.md) for additional optional flags to set.
-
-<pre>
-  <code>
-  WITHDRAWAL_ADDR=[ENTER YOUR WITHDRAWAL ADDRESS HERE]
-  <br/>
-  FEE_RECIPIENT_ADDR=[ENTER YOUR FEE RECIPIENT ADDRESS HERE]
-  <br/>
-  NETWORK="holesky"
-  </code>
-</pre>
-
- 
-3. Once you have set the values you wish to use. Make a copy of this file called `.env`.
+`.env.sample` is a sample environment file that allows overriding default configuration defined in `docker-compose.yml`. Setup the desired settings for the DV by uncommenting lines and setting values. Once you have set the values you wish to use, make a copy of this file called `.env`.
 
 ```bash
 # Copy the sample environment variables
 cp .env.sample .env
 ```
 
-4.  Then, run this command to create all the key shares and cluster artifacts locally:
+3. Run the cluster creation command, setting required flag values
+
+Run the below command to create all the key shares and cluster artifacts locally, manually setting the values of flags “nodes”, “network”, “num-validators”, “fee-recipient-addresses”,  and “withdrawal-addresses”. 
+Check the [Charon CLI reference](../charon/charon-cli-reference.md#create-a-full-cluster-locally) for additional, optional flags to set.
 
 <pre>
-  docker run --rm -v "$(pwd):/opt/charon" --env-file .env obolnetwork/charon:v0.19.0 create cluster 
+  docker run --rm -v "$(pwd):/opt/charon" --env-file .env obolnetwork/charon:v0.19.1 create cluster --nodes=4 --network=holesky --num-validators=1 --fee-recipient-addresses=[ENTER YOUR FEE RECIPIENT ADDRESS HERE] --withdrawal-addresses=[ENTER YOUR WITHDRAWAL ADDRESS HERE]
 </pre>
   </TabItem>
 </Tabs>
 <br />
 
-You should now have multiple folders within `./cluster/`, one for each node created. Backup the `./cluster/` folder, then move on to deploying the cluster physically.
+After the command is run, you should have multiple folders within `./cluster/`, one for each node created. Backup the `./cluster/` folder, then move on to deploying the cluster.
 
 ## Step 2: Deploy and start the nodes
 

--- a/versioned_docs/version-v0.19.1/start/quickstart_alone.md
+++ b/versioned_docs/version-v0.19.1/start/quickstart_alone.md
@@ -29,10 +29,7 @@ The private key shares can be created centrally and distributed securely to each
 
 <Tabs groupId="Launchpad-other">
   <TabItem value="Launchpad" label="Launchpad" default>
-Go to the the <a href="/docs/dvl/intro#dv-launchpad-links">DV Launchpad</a> and select <code>Create a distributed validator alone</code>. Follow the steps to configure your DV cluster. The Launchpad will give you a docker command, which you should run in your terminal.
-
-<br/><br/>
-Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">Quickstart Alone</a> demo repo and `cd` into the directory.
+    Go to the the <a href="/docs/dvl/intro#dv-launchpad-links">DV Launchpad</a> and select <code>Create a distributed validator alone</code>. Follow the steps to configure your DV cluster. The Launchpad will give you a docker command to create your cluster. <br/>Before you run the command, checkout the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">Quickstart Alone</a> demo repo and <code>cd</code> into the directory.
 
   ```bash
   # Clone the repo
@@ -40,11 +37,15 @@ Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-c
 
   # Change directory
   cd charon-distributed-validator-cluster/
+
+  # Run the command provided in the DV Launchpad "Create a cluster alone" flow
+  docker run -u $(id -u):$(id -g) --rm -v "$(pwd)/:/opt/charon" obolnetwork/charon:v0.19.1 create cluster --definition-file=...
   ```
   </TabItem>
-  <TabItem value="CLI" label="CLI">
-1. Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">Quickstart Alone</a> demo repo and `cd` into the directory.
 
+  <TabItem value="CLI" label="CLI">
+
+1. Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster">Quickstart Alone</a> demo repo and <code>cd</code> into the directory.
   ```bash
   # Clone the repo
   git clone https://github.com/ObolNetwork/charon-distributed-validator-cluster.git
@@ -52,29 +53,29 @@ Clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-c
   # Change directory
   cd charon-distributed-validator-cluster/
   ```
+2. Run the cluster creation command, setting required flag values.
 
-2. Prepare the environment variables
+  Run the below command to create the validator private key shares and cluster artifacts locally, replacing the example values for `nodes`, `network`, `num-validators`, `fee-recipient-addresses`,  and `withdrawal-addresses`.
+  Check the [Charon CLI reference](../charon/charon-cli-reference.md#create-a-full-cluster-locally) for additional, optional flags to set.
+  ```bash
+    docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v0.19.1 create cluster --nodes=4 --network=holesky --num-validators=1 --name="Quickstart Guide Cluster" --cluster-dir="cluster" --fee-recipient-addresses=0x000000000000000000000000000000000000dead --withdrawal-addresses=0x000000000000000000000000000000000000dead
+  ```
 
-`.env.sample` is a sample environment file that allows overriding default configuration defined in `docker-compose.yml`. Setup the desired settings for the DV by uncommenting lines and setting values. Once you have set the values you wish to use, make a copy of this file called `.env`.
+:::tip
+If you would like your cluster to appear on the [DV Launchpad](../dvl/intro), add the `--publish` flag to the command.
+:::
 
-```bash
-# Copy the sample environment variables
-cp .env.sample .env
-```
-
-3. Run the cluster creation command, setting required flag values
-
-Run the below command to create all the key shares and cluster artifacts locally, manually setting the values of flags “nodes”, “network”, “num-validators”, “fee-recipient-addresses”,  and “withdrawal-addresses”. 
-Check the [Charon CLI reference](../charon/charon-cli-reference.md#create-a-full-cluster-locally) for additional, optional flags to set.
-
-<pre>
-  docker run --rm -v "$(pwd):/opt/charon" --env-file .env obolnetwork/charon:v0.19.1 create cluster --nodes=4 --network=holesky --num-validators=1 --fee-recipient-addresses=[ENTER YOUR FEE RECIPIENT ADDRESS HERE] --withdrawal-addresses=[ENTER YOUR WITHDRAWAL ADDRESS HERE]
-</pre>
   </TabItem>
 </Tabs>
 <br />
 
-After the command is run, you should have multiple folders within `./cluster/`, one for each node created. Backup the `./cluster/` folder, then move on to deploying the cluster.
+After the `create cluster` command is run, you should have multiple subfolders within the newly created `./cluster/` folder, one for each node created.
+
+**Backup the `./cluster/` folder, then move on to deploying the cluster.**
+
+:::info
+Make sure your backup is secure and private, someone with access to these files could get the validators slashed.
+:::
 
 ## Step 2: Deploy and start the nodes
 


### PR DESCRIPTION
To address issue #341
https://github.com/ObolNetwork/obol-docs/issues/341

The quickstart alone guide in the docs was missing the instructions to clone the repo, within the "launchpad" tab. (It was there for the "CLI" tab) 