### PR TITLE
Fixed CDVC link

### DIFF
--- a/docs/start/quickstart_alone.md
+++ b/docs/start/quickstart_alone.md
@@ -88,7 +88,7 @@ This part of the guide only runs one Execution Client, one Consensus Client, and
 For a production deployment with fault tolerance, follow the part of the guide instructing you how to distribute the nodes across multiple machines. 
 :::
 
-Run this command to start your cluster containers if you deployed using CDVC repo above.
+Run this command to start your cluster containers if you deployed using [CDVC repo](https://github.com/ObolNetwork/charon-distributed-validator-cluster).
 
 ```sh
 # Start the distributed validator cluster


### PR DESCRIPTION
## Summary
If the user navigates to this page https://docs.obol.tech/docs/start/quickstart_alone#step-2-deploy-and-start-the-nodes (suggested by the Launchpad), it is unclear what CDVC repo is meant "above". I suggest to set the explicit link in place.

## Details
"CDVC repo" to become the link to the GitHub repository.

ticket:
none
