### PR TITLE
Update quickstart-exit.md

### DIFF
--- a/docs/start/quickstart-exit.md
+++ b/docs/start/quickstart-exit.md
@@ -81,7 +81,7 @@ It needs to be the validator client that is connected to your charon client taki
         </pre>
       </TabItem>
         <TabItem value="lodestar" label="Lodestar" default>
-        The following executes an interactive command inside the Loestar VC container to exit all validators. It executes 
+        The following executes an interactive command inside the Lodestar VC container to exit all validators. It executes 
         <code>node /usr/app/packages/cli/bin/lodestar validator voluntary-exit</code> with the arguments:
         <ul>
           <li><code>--beaconNodes="http://charon:3600"</code> : Specifies the Charon <code>host:port</code>.</li>
@@ -143,7 +143,7 @@ It needs to be the validator client that is connected to your charon client taki
         </pre>
       </TabItem>
         <TabItem value="lodestar" label="Lodestar" default>
-        The following executes an interactive command inside the Loestar VC container to exit all validators. It executes 
+        The following executes an interactive command inside the Lodestar VC container to exit all validators. It executes 
         <code>node /usr/app/packages/cli/bin/lodestar validator voluntary-exit</code> with the arguments:
         <ul>
           <li><code>--beaconNodes="http://charon:3600"</code> : Specifies the Charon <code>host:port</code>.</li>
@@ -205,7 +205,7 @@ It needs to be the validator client that is connected to your charon client taki
         </pre>
       </TabItem>
         <TabItem value="lodestar" label="Lodestar" default>
-        The following executes an interactive command inside the Loestar VC container to exit all validators. It executes 
+        The following executes an interactive command inside the Lodestar VC container to exit all validators. It executes 
         <code>node /usr/app/packages/cli/bin/lodestar validator voluntary-exit</code> with the arguments:
         <ul>
           <li><code>--beaconNodes="http://charon:3600"</code> : Specifies the Charon <code>host:port</code>.</li>


### PR DESCRIPTION
## Summary
Misspell error in the Quick Start "Exit a DV" guide webpage & Github doc: Update quickstart-exit.md

## Details
In the Quickstart guide, there was a misspelling of 'Lodestar' as 'Loestar.' This error could potentially cause confusion for users when searching for relevant keywords. As a proactive measure, corrections have been made in the documentation to ensure accuracy and clarity for users navigating the material.

## ticket:
Docs: Update quickstart-exit.md
Code line: #84 #146 #208
