### PR TITLE
Add `charon exit` to voluntary exits

### DIFF
--- a/docs/charon/charon-cli-reference.md
+++ b/docs/charon/charon-cli-reference.md
@@ -275,19 +275,21 @@ Usage:
   charon exit sign [flags]
 
 Flags:
-      --beacon-node-timeout duration   Timeout for beacon node HTTP calls. (default 30s)
-      --beacon-node-url string         Beacon node URL. [REQUIRED]
-      --exit-epoch uint                Exit epoch at which the validator will exit, must be the same across all the partial exits. (default 162304)
-  -h, --help                           Help for sign
-      --lock-file string               The path to the cluster lock file defining the distributed validator cluster. (default ".charon/cluster-lock.json")
-      --log-color string               Log color; auto, force, disable. (default "auto")
-      --log-format string              Log format; console, logfmt or json (default "console")
-      --log-level string               Log level; debug, info, warn or error (default "info")
-      --log-output-path string         Path in which to write on-disk logs.
-      --private-key-file string        The path to the charon enr private key file.  (default ".charon/charon-enr-private-key")
-      --publish-address string         The URL of the remote API. (default "https://api.obol.tech")
-      --validator-keys-dir string      Path to the directory containing the validator private key share files and passwords. (default ".charon/validator_keys")
-      --validator-public-key string    Public key of the validator to exit, must be present in the cluster lock manifest. [REQUIRED]
+      --beacon-node-endpoints strings   Comma separated list of one or more beacon node endpoint URLs. [REQUIRED]
+      --beacon-node-timeout duration    Timeout for beacon node HTTP calls. (default 30s)
+      --exit-epoch uint                 Exit epoch at which the validator will exit, must be the same across all the partial exits. (default 162304)
+  -h, --help                            Help for sign
+      --lock-file string                The path to the cluster lock file defining the distributed validator cluster. (default ".charon/cluster-lock.json")
+      --log-color string                Log color; auto, force, disable. (default "auto")
+      --log-format string               Log format; console, logfmt or json (default "console")
+      --log-level string                Log level; debug, info, warn or error (default "info")
+      --log-output-path string          Path in which to write on-disk logs.
+      --private-key-file string         The path to the charon enr private key file.  (default ".charon/charon-enr-private-key")
+      --publish-address string          The URL of the remote API. (default "https://api.obol.tech")
+      --publish-timeout duration        Timeout for publishing a signed exit to the publish-address API. (default 30s)
+      --validator-index uint            Validator index of the validator to exit, the associated public key must be present in the cluster lock manifest. If --validator-pubkey is also provided, validator liveliness won't be checked on the beacon chain.
+      --validator-keys-dir string       Path to the directory containing the validator private key share files and passwords. (default ".charon/validator_keys")
+      --validator-public-key string     Public key of the validator to exit, must be present in the cluster lock manifest. If --validator-index is also provided, validator liveliness won't be checked on the beacon chain.
 ```
 
 ### Download fully signed exit messages for cold storage
@@ -302,6 +304,7 @@ Usage:
   charon exit fetch [flags]
 
 Flags:
+      --fetched-exit-path string      Path to store fetched signed exit messages. (default "./")
   -h, --help                          Help for fetch
       --lock-file string              The path to the cluster lock file defining the distributed validator cluster. (default ".charon/cluster-lock.json")
       --log-color string              Log color; auto, force, disable. (default "auto")
@@ -310,7 +313,8 @@ Flags:
       --log-output-path string        Path in which to write on-disk logs.
       --private-key-file string       The path to the charon enr private key file.  (default ".charon/charon-enr-private-key")
       --publish-address string        The URL of the remote API. (default "https://api.obol.tech")
-      --validator-public-key string   Public key of the validator to exit, must be present in the cluster lock manifest. [REQUIRED]
+      --publish-timeout duration      Timeout for publishing a signed exit to the publish-address API. (default 30s)
+      --validator-public-key string   Public key of the validator to exit, must be present in the cluster lock manifest. If --validator-index is also provided, validator liveliness won't be checked on the beacon chain. [REQUIRED]
 ```
 
 ### Broadcast a signed exit message
@@ -325,20 +329,21 @@ Usage:
   charon exit broadcast [flags]
 
 Flags:
-      --beacon-node-timeout duration   Timeout for beacon node HTTP calls. (default 30s)
-      --beacon-node-url string         Beacon node URL. [REQUIRED]
-      --exit-epoch uint                Exit epoch at which the validator will exit, must be the same across all the partial exits. (default 162304)
-      --exit-from-file string          Retrieves a signed exit message from a pre-prepared file instead of --publish-address.
-  -h, --help                           Help for broadcast
-      --lock-file string               The path to the cluster lock file defining the distributed validator cluster. (default ".charon/cluster-lock.json")
-      --log-color string               Log color; auto, force, disable. (default "auto")
-      --log-format string              Log format; console, logfmt or json (default "console")
-      --log-level string               Log level; debug, info, warn or error (default "info")
-      --log-output-path string         Path in which to write on-disk logs.
-      --private-key-file string        The path to the charon enr private key file.  (default ".charon/charon-enr-private-key")
-      --publish-address string         The URL of the remote API. (default "https://api.obol.tech")
-      --validator-keys-dir string      Path to the directory containing the validator private key share files and passwords. (default ".charon/validator_keys")
-      --validator-public-key string    Public key of the validator to exit, must be present in the cluster lock manifest. [REQUIRED]
+      --beacon-node-endpoints strings   Comma separated list of one or more beacon node endpoint URLs. [REQUIRED]
+      --beacon-node-timeout duration    Timeout for beacon node HTTP calls. (default 30s)
+      --exit-epoch uint                 Exit epoch at which the validator will exit, must be the same across all the partial exits. (default 162304)
+      --exit-from-file string           Retrieves a signed exit message from a pre-prepared file instead of --publish-address.
+  -h, --help                            Help for broadcast
+      --lock-file string                The path to the cluster lock file defining the distributed validator cluster. (default ".charon/cluster-lock.json")
+      --log-color string                Log color; auto, force, disable. (default "auto")
+      --log-format string               Log format; console, logfmt or json (default "console")
+      --log-level string                Log level; debug, info, warn or error (default "info")
+      --log-output-path string          Path in which to write on-disk logs.
+      --private-key-file string         The path to the charon enr private key file.  (default ".charon/charon-enr-private-key")
+      --publish-address string          The URL of the remote API. (default "https://api.obol.tech")
+      --publish-timeout duration        Timeout for publishing a signed exit to the publish-address API. (default 30s)
+      --validator-keys-dir string       Path to the directory containing the validator private key share files and passwords. (default ".charon/validator_keys")
+      --validator-public-key string     Public key of the validator to exit, must be present in the cluster lock manifest. If --validator-index is also provided, validator liveliness won't be checked on the beacon chain. [REQUIRED]
 ```
 
 ## The `combine` command

--- a/docs/start/quickstart-exit.md
+++ b/docs/start/quickstart-exit.md
@@ -105,7 +105,8 @@ It needs to be the validator client that is connected to your charon client taki
       Voluntary exit can be submitted directly through Charon as well. The partially signed exit messages are stored (centrally) on Obol's infrastructure. Exits through Charon are submitted per validator. All active validators public keys for a given cluster lock can be listed with:
         <pre>
           <code>
-        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit active-validator-list'`}
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit active-validator-list \
+    --beacon-node-endpoints="http://lighthouse:5052"'`}
           </code>
         </pre>
       Then a signed partial exit for validator can be submitted by:
@@ -198,7 +199,8 @@ It needs to be the validator client that is connected to your charon client taki
       Voluntary exit can be submitted directly through charon as well. The partially signed exit messages are stored (centrally) on Obol's infrastructure. Exits through charon are submitted per validator. All active validators' public keys can be listed with:
         <pre>
           <code>
-        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit active-validator-list'`}
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit active-validator-list \
+    --beacon-node-endpoints="http://lighthouse:5052"'`}
           </code>
         </pre>
       Then a signed partial exit for validator can be submitted by:
@@ -291,7 +293,8 @@ It needs to be the validator client that is connected to your charon client taki
       Voluntary exit can be submitted directly through charon as well. The partially signed exit messages are stored (centrally) on Obol's infrastructure. Exits through charon are submitted per validator. All active validators' public keys can be listed with:
         <pre>
           <code>
-        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit active-validator-list'`}
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit active-validator-list \
+    --beacon-node-endpoints="http://lighthouse:5052"'`}
           </code>
         </pre>
       Then a signed partial exit for validator can be submitted by:

--- a/docs/start/quickstart-exit.md
+++ b/docs/start/quickstart-exit.md
@@ -102,7 +102,7 @@ It needs to be the validator client that is connected to your charon client taki
         </pre>
       </TabItem>
       <TabItem value="charon" label="Charon" default>
-      Voluntary exit can be submitted directly through charon as well. The partially signed exit messages are stored (centrally) on Obol's infrastructure. Exits through charon are submitted per validator. All active validators' public keys can be listed with:
+      Voluntary exit can be submitted directly through Charon as well. The partially signed exit messages are stored (centrally) on Obol's infrastructure. Exits through Charon are submitted per validator. All active validators public keys for a given cluster lock can be listed with:
         <pre>
           <code>
         {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit active-validator-list'`}

--- a/docs/start/quickstart-exit.md
+++ b/docs/start/quickstart-exit.md
@@ -118,7 +118,7 @@ It needs to be the validator client that is connected to your charon client taki
     --publish-timeout="5m"'`}
           </code>
         </pre>
-      After a sufficient amount of signed partial exits from node operators in the cluster is cumulated, a full (complete) exit is created. The threshold is the same as the one submitted during creating of the cluster. After a full exit message is created, any operator from the cluster can broadcast it to the beacon chain with:
+      After a sufficient amount of signed partial exits from node operators in the cluster is cumulated, a full (complete) exit is created. The threshold is the same as the one submitted during the cluster creation. After a full exit message is created, any operator from the cluster can broadcast it to the beacon chain with:
         <pre>
           <code>
         {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit broadcast \
@@ -212,7 +212,7 @@ It needs to be the validator client that is connected to your charon client taki
     --publish-timeout="5m"'`}
           </code>
         </pre>
-      After a sufficient amount of signed partial exits from node operators in the cluster is cumulated, a full (complete) exit is created. The threshold is the same as the one submitted during creating of the cluster. After a full exit message is created, any operator from the cluster can broadcast it to the beacon chain with:
+      After a sufficient amount of signed partial exits from node operators in the cluster is cumulated, a full (complete) exit is created. The threshold is the same as the one submitted during the cluster creation. After a full exit message is created, any operator from the cluster can broadcast it to the beacon chain with:
         <pre>
           <code>
         {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit broadcast \
@@ -306,7 +306,7 @@ It needs to be the validator client that is connected to your charon client taki
     --publish-timeout="5m"'`}
           </code>
         </pre>
-      After a sufficient amount of signed partial exits from node operators in the cluster is cumulated, a full (complete) exit is created. The threshold is the same as the one submitted during creating of the cluster. After a full exit message is created, any operator from the cluster can broadcast it to the beacon chain with:
+      After a sufficient amount of signed partial exits from node operators in the cluster is cumulated, a full (complete) exit is created. The threshold is the same as the one submitted during the cluster creation. After a full exit message is created, any operator from the cluster can broadcast it to the beacon chain with:
         <pre>
           <code>
         {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit broadcast \

--- a/docs/start/quickstart-exit.md
+++ b/docs/start/quickstart-exit.md
@@ -41,11 +41,11 @@ It needs to be the validator client that is connected to your charon client taki
       <TabItem value="teku" label="Teku" default>
         <pre>
           <code>
-        {String.raw`docker exec -ti charon-distributed-validator-node-teku-1 /opt/teku/bin/teku voluntary-exit \
-        --beacon-node-api-endpoint="http://charon:3600/" \
-        --confirmation-enabled=false \
-        --validator-keys="/opt/charon/validator_keys:/opt/charon/validator_keys" \
-        --epoch=162304`}
+            {String.raw`docker exec -it charon-distributed-validator-node-teku-1 /opt/teku/bin/teku voluntary-exit \
+            --beacon-node-api-endpoint="http://charon:3600/" \
+            --confirmation-enabled=false \
+            --validator-keys="/opt/charon/validator_keys:/opt/charon/validator_keys" \
+            --epoch=162304`}
           </code>
         </pre>
       </TabItem>
@@ -65,7 +65,7 @@ It needs to be the validator client that is connected to your charon client taki
         </ul>
         <pre>
           <code>
-            {String.raw`docker exec -it charon-distributed-validator-node-nimbus-1 /bin/bash -c '\
+            {String.raw`docker exec -it charon-distributed-validator-node-nimbus-1 /bin/bash -c ' \
         
             mkdir /home/user/data/wd
             cp -r /home/user/data/charon/ /home/user/data/wd
@@ -92,7 +92,12 @@ It needs to be the validator client that is connected to your charon client taki
         </ul>
         <pre>
           <code>
-            {String.raw`docker exec -it charon-distributed-validator-node-lodestar-1 /bin/sh -c 'node /usr/app/packages/cli/bin/lodestar validator voluntary-exit --beaconNodes="http://charon:3600" --dataDir=/opt/data --exitEpoch=162304 --network=goerli --yes'`}
+            {String.raw`docker exec -it charon-distributed-validator-node-lodestar-1 /bin/sh -c 'node /usr/app/packages/cli/bin/lodestar validator voluntary-exit \
+            --beaconNodes="http://charon:3600" \
+            --dataDir=/opt/data \
+            --exitEpoch=162304 \
+            --network=goerli \
+            --yes'`}
           </code>
         </pre>
       </TabItem>
@@ -129,7 +134,7 @@ It needs to be the validator client that is connected to your charon client taki
       <TabItem value="teku" label="Teku" default>
         <pre>
           <code>
-            {String.raw`docker exec -ti charon-distributed-validator-node-teku-1 /opt/teku/bin/teku voluntary-exit \
+            {String.raw`docker exec -it charon-distributed-validator-node-teku-1 /opt/teku/bin/teku voluntary-exit \
             --beacon-node-api-endpoint="http://charon:3600/" \
             --confirmation-enabled=false \
             --validator-keys="/opt/charon/validator_keys:/opt/charon/validator_keys" \
@@ -153,7 +158,7 @@ It needs to be the validator client that is connected to your charon client taki
         </ul>
         <pre>
           <code>
-            {String.raw`docker exec -it charon-distributed-validator-node-nimbus-1 /bin/bash -c '\
+            {String.raw`docker exec -it charon-distributed-validator-node-nimbus-1 /bin/bash -c ' \
         
             mkdir /home/user/data/wd
             cp -r /home/user/data/charon/ /home/user/data/wd
@@ -180,7 +185,12 @@ It needs to be the validator client that is connected to your charon client taki
         </ul>
         <pre>
           <code>
-           {String.raw`docker exec -it charon-distributed-validator-node-lodestar-1 /bin/sh -c 'node /usr/app/packages/cli/bin/lodestar validator voluntary-exit --beaconNodes="http://charon:3600" --dataDir=/opt/data --exitEpoch=256 --network=holesky --yes'`}
+            {String.raw`docker exec -it charon-distributed-validator-node-lodestar-1 /bin/sh -c 'node /usr/app/packages/cli/bin/lodestar validator voluntary-exit \
+            --beaconNodes="http://charon:3600" \
+            --dataDir=/opt/data \
+            --exitEpoch=256 \
+            --network=holesky \
+            --yes'`}
           </code>
         </pre>
       </TabItem>
@@ -217,7 +227,7 @@ It needs to be the validator client that is connected to your charon client taki
       <TabItem value="teku" label="Teku" default>
         <pre>
           <code>
-            {String.raw`docker exec -ti charon-distributed-validator-node-teku-1 /opt/teku/bin/teku voluntary-exit \
+            {String.raw`docker exec -it charon-distributed-validator-node-teku-1 /opt/teku/bin/teku voluntary-exit \
             --beacon-node-api-endpoint="http://charon:3600/" \
             --confirmation-enabled=false \
             --validator-keys="/opt/charon/validator_keys:/opt/charon/validator_keys" \
@@ -241,7 +251,7 @@ It needs to be the validator client that is connected to your charon client taki
         </ul>
         <pre>
           <code>
-            {String.raw`docker exec -it charon-distributed-validator-node-nimbus-1 /bin/bash -c '\
+            {String.raw`docker exec -it charon-distributed-validator-node-nimbus-1 /bin/bash -c ' \
         
             mkdir /home/user/data/wd
             cp -r /home/user/data/charon/ /home/user/data/wd
@@ -268,7 +278,12 @@ It needs to be the validator client that is connected to your charon client taki
         </ul>
         <pre>
           <code>
-           {String.raw`docker exec -it charon-distributed-validator-node-lodestar-1 /bin/sh -c 'node /usr/app/packages/cli/bin/lodestar validator voluntary-exit --beaconNodes="http://charon:3600" --dataDir=/opt/data --exitEpoch=194048 --network=mainnet --yes'`}
+            {String.raw`docker exec -it charon-distributed-validator-node-lodestar-1 /bin/sh -c 'node /usr/app/packages/cli/bin/lodestar validator voluntary-exit \
+            --beaconNodes="http://charon:3600" \
+            --dataDir=/opt/data \
+            --exitEpoch=194048 \
+            --network=mainnet \
+            --yes'`}
           </code>
         </pre>
       </TabItem>

--- a/docs/start/quickstart-exit.md
+++ b/docs/start/quickstart-exit.md
@@ -118,7 +118,7 @@ It needs to be the validator client that is connected to your charon client taki
     --publish-timeout="5m"'`}
           </code>
         </pre>
-      After the threshold of signed partial exits is met, any operator from the cluster can broadcast the full signed exit to the beacon chain:
+      After a sufficient amount of signed partial exits from node operators in the cluster is cumulated, a full (complete) exit is created. The threshold is the same as the one submitted during creating of the cluster. After a full exit message is created, any operator from the cluster can broadcast it to the beacon chain with:
         <pre>
           <code>
         {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit broadcast \
@@ -212,7 +212,7 @@ It needs to be the validator client that is connected to your charon client taki
     --publish-timeout="5m"'`}
           </code>
         </pre>
-      After the threshold of signed partial exits is met, any operator from the cluster can broadcast the full signed exit to the beacon chain:
+      After a sufficient amount of signed partial exits from node operators in the cluster is cumulated, a full (complete) exit is created. The threshold is the same as the one submitted during creating of the cluster. After a full exit message is created, any operator from the cluster can broadcast it to the beacon chain with:
         <pre>
           <code>
         {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit broadcast \
@@ -306,7 +306,7 @@ It needs to be the validator client that is connected to your charon client taki
     --publish-timeout="5m"'`}
           </code>
         </pre>
-      After the threshold of signed partial exits is met, any operator from the cluster can broadcast the full signed exit to the beacon chain:
+      After a sufficient amount of signed partial exits from node operators in the cluster is cumulated, a full (complete) exit is created. The threshold is the same as the one submitted during creating of the cluster. After a full exit message is created, any operator from the cluster can broadcast it to the beacon chain with:
         <pre>
           <code>
         {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit broadcast \

--- a/docs/start/quickstart-exit.md
+++ b/docs/start/quickstart-exit.md
@@ -96,6 +96,32 @@ It needs to be the validator client that is connected to your charon client taki
           </code>
         </pre>
       </TabItem>
+      <TabItem value="charon" label="Charon" default>
+      Voluntary exit can be submitted directly through charon as well. The partially signed exit messages are stored (centrally) on Obol's infrastructure. Exits through charon are submitted per validator. All active validators' public keys can be listed with:
+        <pre>
+          <code>
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit active-validator-list'`}
+          </code>
+        </pre>
+      Then a signed partial exit for validator can be submitted by:
+        <pre>
+          <code>
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit sign \
+    --beacon-node-endpoints="http://lighthouse:5052" \
+    --validator-public-key="<VALIDATOR_PUBLIC_KEY>" \
+    --publish-timeout="5m"'`}
+          </code>
+        </pre>
+      After the threshold of signed partial exits is met, any operator from the cluster can broadcast the full signed exit to the beacon chain:
+        <pre>
+          <code>
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit broadcast \
+    --beacon-node-endpoints="http://lighthouse:5052" \
+    --validator-public-key="<VALIDATOR_PUBLIC_KEY>" \
+    --publish-timeout="5m"'`}
+          </code>
+        </pre>
+      </TabItem>
     </Tabs>
   </TabItem>
   <TabItem value="Holesky" label="Holesky">
@@ -155,6 +181,32 @@ It needs to be the validator client that is connected to your charon client taki
         <pre>
           <code>
            {String.raw`docker exec -it charon-distributed-validator-node-lodestar-1 /bin/sh -c 'node /usr/app/packages/cli/bin/lodestar validator voluntary-exit --beaconNodes="http://charon:3600" --dataDir=/opt/data --exitEpoch=256 --network=holesky --yes'`}
+          </code>
+        </pre>
+      </TabItem>
+      <TabItem value="charon" label="Charon" default>
+      Voluntary exit can be submitted directly through charon as well. The partially signed exit messages are stored (centrally) on Obol's infrastructure. Exits through charon are submitted per validator. All active validators' public keys can be listed with:
+        <pre>
+          <code>
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit active-validator-list'`}
+          </code>
+        </pre>
+      Then a signed partial exit for validator can be submitted by:
+        <pre>
+          <code>
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit sign \
+    --beacon-node-endpoints="http://lighthouse:5052" \
+    --validator-public-key="<VALIDATOR_PUBLIC_KEY>" \
+    --publish-timeout="5m"'`}
+          </code>
+        </pre>
+      After the threshold of signed partial exits is met, any operator from the cluster can broadcast the full signed exit to the beacon chain:
+        <pre>
+          <code>
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit broadcast \
+    --beacon-node-endpoints="http://lighthouse:5052" \
+    --validator-public-key="<VALIDATOR_PUBLIC_KEY>" \
+    --publish-timeout="5m"'`}
           </code>
         </pre>
       </TabItem>
@@ -220,11 +272,37 @@ It needs to be the validator client that is connected to your charon client taki
           </code>
         </pre>
       </TabItem>
+      <TabItem value="charon" label="Charon" default>
+      Voluntary exit can be submitted directly through charon as well. The partially signed exit messages are stored (centrally) on Obol's infrastructure. Exits through charon are submitted per validator. All active validators' public keys can be listed with:
+        <pre>
+          <code>
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit active-validator-list'`}
+          </code>
+        </pre>
+      Then a signed partial exit for validator can be submitted by:
+        <pre>
+          <code>
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit sign \
+    --beacon-node-endpoints="http://lighthouse:5052" \
+    --validator-public-key="<VALIDATOR_PUBLIC_KEY>" \
+    --publish-timeout="5m"'`}
+          </code>
+        </pre>
+      After the threshold of signed partial exits is met, any operator from the cluster can broadcast the full signed exit to the beacon chain:
+        <pre>
+          <code>
+        {String.raw`docker exec -it charon-distributed-validator-node-charon-1 /bin/sh -c 'charon exit broadcast \
+    --beacon-node-endpoints="http://lighthouse:5052" \
+    --validator-public-key="<VALIDATOR_PUBLIC_KEY>" \
+    --publish-timeout="5m"'`}
+          </code>
+        </pre>
+      </TabItem>
     </Tabs>
   </TabItem>
 </Tabs>
 
-Once a threshold of exit signatures has been received by any single charon client, it will craft a valid voluntary exit message and will submit it to the beacon chain for inclusion. You can monitor partial exits stored by each node in the [Grafana Dashboard](https://github.com/ObolNetwork/charon-distributed-validator-node).
+When submitting through a validator client (not through charon directly), once a threshold of exit signatures has been received by any single charon client, it will craft a valid voluntary exit message and will submit it to the beacon chain for inclusion. You can monitor partial exits stored by each node in the [Grafana Dashboard](https://github.com/ObolNetwork/charon-distributed-validator-node).
 
 ## Exit epoch and withdrawable epoch
 


### PR DESCRIPTION
- Add voluntary exits directly from `charon exit` to the docs.
- Update the CLI docs with the updates flags for `charon exit`.
- Small consistency fixes for voluntary exits.
