### PR TITLE
Prometheus container restart

### DIFF
--- a/docs/advanced/obol-monitoring.md
+++ b/docs/advanced/obol-monitoring.md
@@ -47,3 +47,9 @@ scrape_configs:
     static_configs:
       - targets: [ "lodestar:5064" ]
 ```
+
+After updating and saving the `prometheus/prometheus.yml`, you must restart the `prometheus` container for the monitoring credentials to take effect:
+
+```shell
+docker compose restart prometheus
+```


### PR DESCRIPTION
## Summary
Add a step to restart the prometheus container after adding the monitoring token

## Details
The prometheus container must be restarted to apply the token configuration updates and allow it to take effect.

ticket:
<!--link to a GitHub issue (or 'none' if PR is trivial)-->
