### PR TITLE
Add obol status page to docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -237,6 +237,10 @@ const config = {
                 label: "GitHub",
                 to: "https://github.com/obolnetwork/",
               },
+              {
+                label: "Status",
+                to: "https://status.obol.org/",
+              },
             ],
           },
         ],


### PR DESCRIPTION
## Summary

Links https://status.obol.org in the docs footer. 