### PR TITLE
Update cp .env.sample to cp .env.sample.holesky

### DIFF
--- a/docs/start/quickstart_alone.mdx
+++ b/docs/start/quickstart_alone.mdx
@@ -190,7 +190,7 @@ cluster
 
   ```shell
   # Copy ".env.sample", renaming it ".env"
-  cp .env.sample .env
+  cp .env.sample.holesky .env
   ```
 
 :::

--- a/docs/start/quickstart_group.mdx
+++ b/docs/start/quickstart_group.mdx
@@ -482,7 +482,7 @@ Setup the desired inputs for the DV, including the network you wish to operate o
 
 ```shell
 # Copy ".env.sample", renaming it ".env"
-cp .env.sample .env
+cp .env.sample.holesky .env
 ```
 
 :::


### PR DESCRIPTION
## Summary
In CDVN we are introducing a change where we have clearer separation of holesky and mainnet configs. Update the docs to address that.

See more in the CDVN PR [here](https://github.com/ObolNetwork/charon-distributed-validator-node/pull/283/files#diff-fbf09cc662e59b5c6aa818f3118ec67634776e03ef88f03e50d81bb9b3ae154c).

ticket: none
