### PR TITLE
updating monitoring page to talk about .env file

### DIFF
--- a/docs/advanced/obol-monitoring.md
+++ b/docs/advanced/obol-monitoring.md
@@ -9,47 +9,19 @@ description: Add monitoring credentials to help the Obol Team monitor the health
 This is **optional** and does not confer any special privileges within the Obol Network.
 :::
 
-You may have been provided with **Monitoring Credentials** used to push distributed validator metrics to Obol's central Prometheus cluster to monitor, analyze, and improve your Distributed Validator Cluster's performance.
+You may have been provided with **Monitoring Credentials** used to push distributed validator metrics to Obol's central Prometheus cluster to monitor, analyze, and improve your Distributed Validator Cluster's performance. (For example, this is necessary to participate in the Obol [Techne](https://squadstaking.com/techne) credential program.) 
 
-The provided credentials needs to be added in `prometheus/prometheus.yml` replacing `$PROM_REMOTE_WRITE_TOKEN` and will look like:
+## Update the monitoring token in the `.env` file  
+- Inside your `.env` file, uncomment the `PROM_REMOTE_WRITE_TOKEN` line by removing the `#` symbol.  
+- Enter your monitoring token in the format shown below:
 
-```shell
-obol20tnt8UC...
+```bash
+PROM_REMOTE_WRITE_TOKEN=your_monitoring_token
 ```
 
-The updated `prometheus/prometheus.yml` file should look like:
+## Save the `.env` file and restart Prometheus  
+Save the .env file, and restart Prometheus to apply the changes:
 
-```yaml
-global:
-  scrape_interval:     30s # Set the scrape interval to every 30 seconds.
-  evaluation_interval: 30s # Evaluate rules every 30 seconds.
-
-remote_write:
-  - url: https://vm.monitoring.gcp.obol.tech/write
-    authorization:
-      credentials: obol20tnt8UC-your-credential-here...
-    write_relabel_configs:
-      - source_labels: [job]
-        regex: "charon"
-        action: keep # Keeps charon metrics and drop metrics from other containers.
-
-scrape_configs:
-  - job_name: "nethermind"
-    static_configs:
-      - targets: ["nethermind:8008"]
-  - job_name: "lighthouse"
-    static_configs:
-      - targets: ["lighthouse:5054"]
-  - job_name: "charon"
-    static_configs:
-      - targets: ["charon:3620"]
-  - job_name: "lodestar"
-    static_configs:
-      - targets: [ "lodestar:5064" ]
-```
-
-After updating and saving the `prometheus/prometheus.yml`, you must restart the `prometheus` container for the monitoring credentials to take effect:
-
-```shell
+```bash
 docker compose restart prometheus
 ```

--- a/docs/advanced/obol-monitoring.md
+++ b/docs/advanced/obol-monitoring.md
@@ -15,7 +15,7 @@ You may have been provided with **Monitoring Credentials** used to push distribu
 - Inside your `.env` file, uncomment the `PROM_REMOTE_WRITE_TOKEN` line by removing the `#` symbol.  
 - Enter your monitoring token in the format shown below:
 
-```bash
+```shell
 PROM_REMOTE_WRITE_TOKEN=your_monitoring_token
 ```
 

--- a/docs/advanced/obol-monitoring.md
+++ b/docs/advanced/obol-monitoring.md
@@ -22,6 +22,6 @@ PROM_REMOTE_WRITE_TOKEN=your_monitoring_token
 ## Save the `.env` file and restart Prometheus  
 Save the .env file, and restart Prometheus to apply the changes:
 
-```bash
+```shell
 docker compose restart prometheus
 ```


### PR DESCRIPTION
A few users have been experiencing issues lately trying to set up their monitoring credentials to push metrics to us.
After investigating the issue where users were unable to save changes to prometheus/prometheus.yml after adding credentials, it appears the root cause is related to how the configuration files are managed. The fix seems to be in modifying the variable in prometheus.yml.example, as this is where the main file draws its instructions.

While modifying prometheus.yml.example does work, the cleaner solution is to use the .env file and declare the PROM_REMOTE_WRITE_TOKEN variable, as shown in .env.sample.holesky  (for Testnet, same process for Mainnet)
This would keep all variables centralized in the .env file and avoid manual edits to the Prometheus config files.

Discussion here:
https://obollabs.slack.com/archives/C05G9SBSD6W/p1727429342425849

See also: https://github.com/ObolNetwork/charon-distributed-validator-node/pull/288
