### PR TITLE
moving the new .env based monitoring info into main

### DIFF
--- a/versioned_docs/version-v1.1.1/advanced/obol-monitoring copy.md
+++ b/versioned_docs/version-v1.1.1/advanced/obol-monitoring copy.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 3
+description: Add monitoring credentials to help the Obol Team monitor the health of your cluster
+---
+
+# Push Metrics to Obol Monitoring
+
+:::info
+This is **optional** and does not confer any special privileges within the Obol Network.
+:::
+
+You may have been provided with **Monitoring Credentials** used to push distributed validator metrics to Obol's central Prometheus cluster to monitor, analyze, and improve your Distributed Validator Cluster's performance. (For example, this is necessary to participate in the Obol [Techne](https://squadstaking.com/techne) credential program.) 
+
+## Update the monitoring token in the `.env` file  
+- Inside your `.env` file, uncomment the `PROM_REMOTE_WRITE_TOKEN` line by removing the `#` symbol.  
+- Enter your monitoring token in the format shown below:
+
+```shell
+PROM_REMOTE_WRITE_TOKEN=your_monitoring_token
+```
+
+## Save the `.env` file and restart Prometheus  
+Save the .env file, and restart Prometheus to apply the changes:
+
+```shell
+docker compose restart prometheus
+```


### PR DESCRIPTION
Moving this from "next" into main v1.1.1 since it's already live in CDVN. 
(see Kalo's PR: https://github.com/ObolNetwork/charon-distributed-validator-node/pull/288)

(To "push monitoring to Obol", the user now edits the .env file) 