### PR TITLE
updating main with new monitoring info

### DIFF
--- a/versioned_docs/version-v1.1.1/advanced/obol-monitoring.md
+++ b/versioned_docs/version-v1.1.1/advanced/obol-monitoring.md
@@ -9,46 +9,18 @@ description: Add monitoring credentials to help the Obol Team monitor the health
 This is **optional** and does not confer any special privileges within the Obol Network.
 :::
 
-You may have been provided with **Monitoring Credentials** used to push distributed validator metrics to Obol's central Prometheus cluster to monitor, analyze, and improve your Distributed Validator Cluster's performance.
+You may have been provided with **Monitoring Credentials** used to push distributed validator metrics to Obol's central Prometheus cluster to monitor, analyze, and improve your Distributed Validator Cluster's performance. (For example, this is necessary to participate in the Obol [Techne](https://squadstaking.com/techne) credential program.) 
 
-The provided credentials needs to be added in `prometheus/prometheus.yml` replacing `$PROM_REMOTE_WRITE_TOKEN` and will look like:
+## Update the monitoring token in the `.env` file  
+- Inside your `.env` file, uncomment the `PROM_REMOTE_WRITE_TOKEN` line by removing the `#` symbol.  
+- Enter your monitoring token in the format shown below:
 
 ```shell
-obol20tnt8UC...
+PROM_REMOTE_WRITE_TOKEN=your_monitoring_token
 ```
 
-The updated `prometheus/prometheus.yml` file should look like:
-
-```yaml
-global:
-  scrape_interval:     30s # Set the scrape interval to every 30 seconds.
-  evaluation_interval: 30s # Evaluate rules every 30 seconds.
-
-remote_write:
-  - url: https://vm.monitoring.gcp.obol.tech/write
-    authorization:
-      credentials: obol20tnt8UC-your-credential-here...
-    write_relabel_configs:
-      - source_labels: [job]
-        regex: "charon"
-        action: keep # Keeps charon metrics and drop metrics from other containers.
-
-scrape_configs:
-  - job_name: "nethermind"
-    static_configs:
-      - targets: ["nethermind:8008"]
-  - job_name: "lighthouse"
-    static_configs:
-      - targets: ["lighthouse:5054"]
-  - job_name: "charon"
-    static_configs:
-      - targets: ["charon:3620"]
-  - job_name: "lodestar"
-    static_configs:
-      - targets: [ "lodestar:5064" ]
-```
-
-After updating and saving the `prometheus/prometheus.yml`, you must restart the `prometheus` container for the monitoring credentials to take effect:
+## Save the `.env` file and restart Prometheus  
+Save the .env file, and restart Prometheus to apply the changes:
 
 ```shell
 docker compose restart prometheus


### PR DESCRIPTION
Moving this from "next" into main v1.1.1 since it's already live in CDVN.
(see Kalo's PR: https://github.com/ObolNetwork/charon-distributed-validator-node/pull/288)

(To "push monitoring to Obol", the user now edits the .env file)