### PR TITLE
Creating CSM page in advanced section

### DIFF
--- a/docs/advanced/lido_csm.md
+++ b/docs/advanced/lido_csm.md
@@ -1,0 +1,22 @@
+---
+sidebar_position: 5
+description: Create a DV within Lido CSM 
+---
+# Create a DV within Lido CSM 
+
+## Setup on Obol Launchpad 
+
+You can use the [Obol Launchpad](../dvl/intro.md) to configure a DV for use within Lido's Community Staking Module (CSM). From within the configuration page of the launchpad:
+
+1. Set the `validators` field to 1 
+(only 1 CSM validator can be deployed per cluster via the launchpad. For multi-validator deployments, use the SDK). 
+2. Set `withdrawal configuration` to `custom`.
+3. Set the `Withdrawal address` set to Lido’s *Withdrawal Vault* address, as per [Lido’s documentation](https://docs.lido.fi/deployed-contracts/holesky/). 
+- On Holesky, this is `0xF0179dEC45a37423EAD4FaD5fCb136197872EAd9` 
+- On Mainnet, this is `0xb9d7934878b5fb9610b3fe8a5e441e8fad7e293f`
+    
+4. Set the `fee recipient` to Lido’s *Execution Layer Rewards Vault* address, as per [Lido’s documentation](https://docs.lido.fi/deployed-contracts/holesky/).  
+- On Holesky, this is `0xE73a3602b99f1f913e72F8bdcBC235e206794Ac8`
+- On Mainnet, this is `0x388C818CA8B9251b393131C08a736A67ccB19297`
+
+Once all operators sign the cluster configuration, the next step is the distributed key generation. If you are not planning on operating a node, and were only configuring the cluster for the operators, your journey ends here. But if you are one of the cluster operators, continue to Step 3 of the [Quickstart](../start/quickstart_group.mdx#step-3-run-the-distributed-key-generation-dkg-ceremony)

--- a/docs/advanced/test-command.md
+++ b/docs/advanced/test-command.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 description: Test the performance of a candidate Distributed Validator Cluster setup.
 ---
 

--- a/docs/start/quickstart_group.mdx
+++ b/docs/start/quickstart_group.mdx
@@ -147,13 +147,7 @@ For Step 2, select the "Creator" tab if you are coordinating the creation of the
       <TabItem value="Launchpad" label="Launchpad" default>
         <p>
           You will use the Launchpad to create an invitation, and share it with
-          the operators.
-          <br />
-          This video shows the flow within the{" "}
-          <a href="/docs/dvl/intro#dv-launchpad-links" target="_blank">
-            DV Launchpad
-          </a>
-          :
+          the operators. This video shows the flow within the [DV Launchpad](../dvl/intro.md)
         </p>
         <p align="center">
           <iframe


### PR DESCRIPTION
As discussed with Oisin and Brett and Kody on October 9th, this PR is creating a new CSM page in the "advanced" section. (The previous PR and branch have been deleted, which attempted to add CSM config info as "info" boxes to the quickstart guides)