### PR TITLE
Fix Typos and Standardize Spelling in Documentation

### DIFF
--- a/docs/advanced/monitoring.md
+++ b/docs/advanced/monitoring.md
@@ -37,7 +37,7 @@ The local Grafana server will have a few pre-built dashboards:
 
 ## Setting Up a Contact Point
 
-When alerts are triggered, they are routed to contact points according notification policies. For this, contact points must be added. Grafana supports several kind of contact points like email, PagerDuty, Discord, Slack, Telegram etc. This document will teach how to add Discord channel as contact point.
+When alerts are triggered, they are routed to contact points according notification policies. For this, contact points must be added. Grafana supports several kinds of contact points like email, PagerDuty, Discord, Slack, Telegram etc. This document will teach how to add Discord channel as contact point.
 
 1. On left nav bar in Grafana console, under `Alerts`  section, click on contact points.
 2. Click on `+ Add contact point`. It will show following page. Choose Discord in the  `Integration` drop down.

--- a/docs/fr/ethereum_and_dvt.md
+++ b/docs/fr/ethereum_and_dvt.md
@@ -37,7 +37,7 @@ Minimizing correlation is vital when designing DVT as Ethereum Proof of Stake is
 [**Read more about Designing Non-Correlation Here**](https://blog.obol.tech/deep-dive-into-dvt-and-charons-architecture/)
 
 ### Performance Testing Distributed Validators
-In our mission to help make Ethereum consensus more resilient and decentralised with distributed validators (DVs), it’s critical that we do not compromise on the performance and effectiveness of validators. Earlier this year, we worked with MigaLabs, the blockchain ecosystem observatory located in Barcelona, to perform an independent test to validate the performance of Obol DVs under different configurations and conditions. After taking a few weeks to fully analyse the results together with MigaLabs, we’re happy to share the results of these performance tests.
+In our mission to help make Ethereum consensus more resilient and decentralized with distributed validators (DVs), it’s critical that we do not compromise on the performance and effectiveness of validators. Earlier this year, we worked with MigaLabs, the blockchain ecosystem observatory located in Barcelona, to perform an independent test to validate the performance of Obol DVs under different configurations and conditions. After taking a few weeks to fully analyse the results together with MigaLabs, we’re happy to share the results of these performance tests.
 
 [**Read More About The Performance Test Results Here**](https://blog.obol.tech/performance-testing-distributed-validators/)
 

--- a/docs/start/quickstart_alone.mdx
+++ b/docs/start/quickstart_alone.mdx
@@ -25,7 +25,7 @@ The private key shares can be created centrally and distributed securely to each
 
 <Tabs groupId="Launchpad-other">
   <TabItem value="Launchpad" label="Launchpad" default>
-    Go to the the <a href="/docs/dvl/intro#dv-launchpad-links">DV Launchpad</a> and select <code>Create a distributed validator alone</code>. Follow the steps to configure your DV cluster. The Launchpad will give you a docker command to create your cluster. <br/>Before you run the command, clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">CDVC repo</a> and <code>cd</code> into the directory.
+    Go to the <a href="/docs/dvl/intro#dv-launchpad-links">DV Launchpad</a> and select <code>Create a distributed validator alone</code>. Follow the steps to configure your DV cluster. The Launchpad will give you a docker command to create your cluster. <br/>Before you run the command, clone the <a href="https://github.com/ObolNetwork/charon-distributed-validator-cluster.git">CDVC repo</a> and <code>cd</code> into the directory.
 
   ```shell
   # Clone the repo

--- a/docs/start/quickstart_group.mdx
+++ b/docs/start/quickstart_group.mdx
@@ -385,7 +385,7 @@ For the [DKG](../charon/dkg.md) to complete, all operators need to be running th
 
    ![Run the DKG](/img/Guide10.png)
 
-3. Assuming the DKG is successful, a number of artefacts will be created in the `.charon` folder of the node. These include:
+3. Assuming the DKG is successful, a number of artifacts will be created in the `.charon` folder of the node. These include:
 
    - A `deposit-data.json` file. This contains the information needed to activate the validator on the Ethereum network.
    - A `cluster-lock.json` file. This contains the information needed by Charon to operate the distributed validator cluster with its peers.
@@ -419,7 +419,7 @@ For the [DKG](../charon/dkg.md) to complete, all operators need to be running th
               <img src="/img/ConnectPeers.png" alt="Connect to peers in logs tab" />
             </li>
              <li>
-              Example of DKG ceremony competed log. 
+              Example of DKG ceremony completed log. 
               <img src="/img/DKGExample.png" alt="Connect to peers in logs tab" />
             </li>
             </ol>


### PR DESCRIPTION
### Summary of Changes

**docs/advanced/monitoring.md**
- `kind ` → `kinds `

**docs/fr/ethereum_and_dvt.md**
- `decentralised ` → `decentralized `

**docs/start/quickstart_alone.mdx**
- `Go to the the ` → `Go to the `

**docs/start/quickstart_group.mdx*
- `artefacts ` → `artifacts `
- `competed ` → `completed `

## Details

This PR fixes several grammatical and spelling errors in the documentation across multiple files for better readability and consistency.

