### PR TITLE
adding links to the quickstart from the dappnode page

### DIFF
--- a/docs/run/integrations/Dappnode.mdx
+++ b/docs/run/integrations/Dappnode.mdx
@@ -5,6 +5,14 @@ description: Dappnode Frequently asked questions
 
 # Dappnode
 
+# Dappnode
+
+## For setup, see quickstart guide:
+
+For setup of a DV using Dappnode, see the quickstart guides, and select the appropriate tabs for "Dappnode":
+- [Create a DV Alone](../start/quickstart_alone.mdx)
+- [Create a DV With a Group](../start/quickstart_group.mdx)
+
 ## Frequently asked questions
 
 ### If an operator uses an ENR to join a cluster, then exits the validator key, do they need to clean up the validator and Charon volumes to use the same ENR for another cluster?

--- a/docs/run/integrations/Dappnode.mdx
+++ b/docs/run/integrations/Dappnode.mdx
@@ -9,9 +9,7 @@ description: Dappnode Frequently asked questions
 
 ## For setup, see quickstart guide:
 
-For setup of a DV using Dappnode, see the quickstart guides, and select the appropriate tabs for "Dappnode":
-- [Create a DV Alone](../start/quickstart_alone.mdx)
-- [Create a DV With a Group](../start/quickstart_group.mdx)
+For setup of a DV using Dappnode, see the quickstart guide [Create a DV Alone](../start/quickstart_alone.mdx), and select the appropriate tab for "Dappnode".
 
 ## Frequently asked questions
 


### PR DESCRIPTION
There now exists a specific page for Dappnode, but it's more of an FAQ. The actual setup info for dappnode is part of the quickstart guides, under "dappnode" tabs. So I added a link to those from the top of the dappnode page, in case someone goes looking there first for the setup information. 