### PR TITLE
deleting the placeholder pages

### DIFF
--- a/docs/run/running/claiming-rewards.md
+++ b/docs/run/running/claiming-rewards.md
@@ -1,9 +1,0 @@
----
-sidebar_position: 5
-description: Claiming rewards from your DV using the Launchpad.
----
-# Claiming DV Rewards
-
-## Claim rewards using the Launchpad. 
-
-This page is currently just a placeholder. Content coming soon. 

--- a/docs/run/start/existing_node.md
+++ b/docs/run/start/existing_node.md
@@ -1,8 +1,0 @@
----
-sidebar_position: 6
-description: Create a DV using an existing beacon node.
----
-
-# Use an Existing Beacon Node
-
-You may have an existing beacon node and wish to use it to run as part of a DV cluster.

--- a/docs/run/start/obol-monitoring.md
+++ b/docs/run/start/obol-monitoring.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 description: Add monitoring credentials to help the Obol Team monitor the health of your cluster
 ---
 import Tabs from "@theme/Tabs";


### PR DESCRIPTION
deleting the placeholder pages on "using an existing beacon node" and also "claiming DV rewards"

For "using an existing beacon node" we already have a section at the end of the group quickstart that I forgot about. I'm not convinced we should have an entire separate page. 

For "claiming DV rewards" I'll submit another PR to add a proper page. Let's avoid having an empty placeholder page in the mean time. 