### PR TITLE
fixing the redirect to the csm page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -222,7 +222,7 @@ const config = {
             from: '/docs/fr/resources',
           },
           {
-            to: '/next/guides/walkthroughs/CSM-walkthrough',
+            to: '/next/run/integrations/lido-csm',
             from: '/docs/advanced/lido_csm',
           },
           {


### PR DESCRIPTION
fixing the redirect to the csm page that is remaining after I deleted the other duplicate one

