### PR TITLE
Change number of nodes in create cluster command

### DIFF
--- a/docs/run/start/quickstart_alone.mdx
+++ b/docs/run/start/quickstart_alone.mdx
@@ -59,7 +59,7 @@ The private key shares can be created centrally and distributed securely to each
 
   ```shell
     docker run --rm -v "$(pwd):/opt/charon" obolnetwork/charon:v1.2.0 create cluster \
-      --nodes=4 \
+      --nodes=6 \
       --network=holesky \
       --num-validators=1 \
       --name="Quickstart Guide Cluster" \


### PR DESCRIPTION
## Summary
Change the create cluster command example to setup 6 nodes instead of 4 nodes to match with the number of nodes in CDVC.

ticket:
none
