### PR TITLE
preparing to unhide the governance pages

### DIFF
--- a/docs/gov/governance/_category_.json
+++ b/docs/gov/governance/_category_.json
@@ -1,6 +1,5 @@
 {
   "label": "Governance",
   "position": 1,
-  "collapsed": true,
-  "className": "hidden"
+  "collapsed": true
 }

--- a/versioned_docs/version-v1.2.0/gov/governance/_category_.json
+++ b/versioned_docs/version-v1.2.0/gov/governance/_category_.json
@@ -1,6 +1,5 @@
 {
   "label": "Governance",
   "position": 1,
-  "collapsed": true,
-  "className": "hidden"
+  "collapsed": true
 }


### PR DESCRIPTION
preparing to undo the changes that Aly did previously:
https://github.com/ObolNetwork/obol-docs/pull/497/files

which hid the governance section so that information about token wasn't displayed prematurely