### PR TITLE
remove this redirect, because it is being done by Aly server-side

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -233,11 +233,6 @@ const config = {
             to: '/sdk',
             from: '/docs/sdk',
           },
-          {
-            to: '/next/gov/community/contributions',
-            from: '/gov/governance/contributions',
-          },
-
           //Redirect from multiple old paths to the new path
           // {
           //   to: '/docs/newDoc2',


### PR DESCRIPTION
Currently this redirect is being handled server-side by Aly. So there is no need for it in the docusaurus config. 

from: https://docs.obol.org/gov/governance/contributions
to: https://docs.obol.org/next/gov/community/contributions