### PR TITLE
Adding links to Atomic Whale's guides

### DIFF
--- a/docs/guides/_category_.json
+++ b/docs/guides/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "BEGINNER GUIDES",
+  "label": "COMMUNITY GUIDES",
   "position": 5,
   "collapsed": false,
   "collapsible": false,

--- a/docs/guides/walkthroughs/walkthrough-guides.md
+++ b/docs/guides/walkthroughs/walkthrough-guides.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-description: Walkthrough guides.
+description: Walkthrough guides
 ---
 
 # Walkthrough Guides
@@ -8,3 +8,27 @@ description: Walkthrough guides.
 This section contains walkthrough guides for beginner users. Some of these guides are specific to particular hardware or operating systems, and may not replace more general documentation. These guides contain more detailed step-by-step information which may be useful for beginner users with limited experience with Linux, validators, and other topics which the primary guides assume some prior familiarity of. 
 
 Some of these guides are community-created, and may contain issues or omissions.
+
+## Running Charon with Native Execution/Consensus Clients - by Atomic Whale
+
+See the guide [here](https://github.com/atomicwhale/obol-guides/blob/main/charon_local-native.md).
+
+This guide covers running Charon with local EC/BN running as system service (systemd). For example, if you have followed one of these guides (Somer Esat Guides / CoinCashew Guides / EthPilar) to set up your node.
+
+## Running Charon with Docker Execution/Consensus Clients - by Atomic Whale
+
+See the guide [here](https://github.com/atomicwhale/obol-guides/blob/main/charon_local-docker.md).
+
+This guide covers running Charon with local EC/BN managed by a docker-based stack (ETH-Docker/Rocket Pool Smart Node).
+
+## Running Charon with remote EC/BN - by Atomic Whale
+
+See the guide [here](https://github.com/atomicwhale/obol-guides/blob/main/charon_remote.md).
+
+This guide covers running Charon with remote EC/BN. For people who already have EC/BN running on a remote/differnt machine, and want to run Charon separately (for example a small VPS).
+
+## Running Multiple Charon instances on one machine 
+
+See the guide [here](https://github.com/atomicwhale/obol-guides/blob/main/charon_multiple.md).
+
+This guide covers steps to run multiple Charon instaces on one machine.

--- a/versioned_docs/version-v1.2.0/guides/_category_.json
+++ b/versioned_docs/version-v1.2.0/guides/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "BEGINNER GUIDES",
+  "label": "COMMUNITY GUIDES",
   "position": 5,
   "collapsed": false,
   "collapsible": false,

--- a/versioned_docs/version-v1.2.0/guides/walkthroughs/walkthrough-guides.md
+++ b/versioned_docs/version-v1.2.0/guides/walkthroughs/walkthrough-guides.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-description: Walkthrough guides.
+description: Walkthrough guides
 ---
 
 # Walkthrough Guides
@@ -8,3 +8,27 @@ description: Walkthrough guides.
 This section contains walkthrough guides for beginner users. Some of these guides are specific to particular hardware or operating systems, and may not replace more general documentation. These guides contain more detailed step-by-step information which may be useful for beginner users with limited experience with Linux, validators, and other topics which the primary guides assume some prior familiarity of. 
 
 Some of these guides are community-created, and may contain issues or omissions.
+
+## Running Charon with Native Execution/Consensus Clients - by Atomic Whale
+
+See the guide [here](https://github.com/atomicwhale/obol-guides/blob/main/charon_local-native.md).
+
+This guide covers running Charon with local EC/BN running as system service (systemd). For example, if you have followed one of these guides (Somer Esat Guides / CoinCashew Guides / EthPilar) to set up your node.
+
+## Running Charon with Docker Execution/Consensus Clients - by Atomic Whale
+
+See the guide [here](https://github.com/atomicwhale/obol-guides/blob/main/charon_local-docker.md).
+
+This guide covers running Charon with local EC/BN managed by a docker-based stack (ETH-Docker/Rocket Pool Smart Node).
+
+## Running Charon with remote EC/BN - by Atomic Whale
+
+See the guide [here](https://github.com/atomicwhale/obol-guides/blob/main/charon_remote.md).
+
+This guide covers running Charon with remote EC/BN. For people who already have EC/BN running on a remote/differnt machine, and want to run Charon separately (for example a small VPS).
+
+## Running Multiple Charon instances on one machine 
+
+See the guide [here](https://github.com/atomicwhale/obol-guides/blob/main/charon_multiple.md).
+
+This guide covers steps to run multiple Charon instaces on one machine.


### PR DESCRIPTION
As discussed, Aly has reviewed the docs and approves of them, [but says](https://obollabs.slack.com/archives/C06FEJ8CDGT/p1736883019908809?thread_ts=1736556778.799109&cid=C06FEJ8CDGT) _"I don’t recommend to add the content to our docs, first it has another owner/maintainer and second it uses different language than ours. I recommend to add just links to these docs and this takes the operators there"_