### PR TITLE
updating RAF language

### DIFF
--- a/docs/gov/governance/raf.md
+++ b/docs/gov/governance/raf.md
@@ -5,9 +5,9 @@ description: The RAF
 
 # The RAF
 
-Obol’s Retroactive Funding (RAF) mechanism is designed to strengthen and promote the decentralisation of Ethereum's settlement layer by rewarding projects that add value and drive impact for Ethereum’s decentralisation. Read more about the Obol RAF [here](https://blog.obol.org/1-percent-for-decentralisation/).
+The Retroactive Funding (RAF) program by the Obol Collective aims to strengthen and promote the Obol Collective’s Decentralized Operator Ecosystem and its ability to scale decentralized infrastructure networks like Ethereum.
 
-Voting and funding distributions occur over a series of **Obol Retroactive Fund (RAF)** rounds, with OBOL token Delegates determining how funds from the RAF are allocated. The first RAF round will open in February 2025.
+Voting and funding distributions occur over a series of **Obol Retroactive Fund (RAF)** rounds, with OBOL token Delegates determining how funds from the RAF are allocated. The [first RAF round](blog.obol.org/raf1/) will open in February 2025, and will focus on public goods. 
 
 ## Overview of the Obol RAF:
 

--- a/versioned_docs/version-v1.2.0/gov/governance/raf.md
+++ b/versioned_docs/version-v1.2.0/gov/governance/raf.md
@@ -5,9 +5,9 @@ description: The RAF
 
 # The RAF
 
-Obol’s Retroactive Funding (RAF) mechanism is designed to strengthen and promote the decentralisation of Ethereum's settlement layer by rewarding projects that add value and drive impact for Ethereum’s decentralisation. Read more about the Obol RAF [here](https://blog.obol.org/1-percent-for-decentralisation/).
+The Retroactive Funding (RAF) program by the Obol Collective aims to strengthen and promote the Obol Collective’s Decentralized Operator Ecosystem and its ability to scale decentralized infrastructure networks like Ethereum.
 
-Voting and funding distributions occur over a series of **Obol Retroactive Fund (RAF)** rounds, with OBOL token Delegates determining how funds from the RAF are allocated. The first RAF round will open in February 2025.
+Voting and funding distributions occur over a series of **Obol Retroactive Fund (RAF)** rounds, with OBOL token Delegates determining how funds from the RAF are allocated. The [first RAF round](blog.obol.org/raf1/) will open in February 2025, and will focus on public goods. 
 
 ## Overview of the Obol RAF:
 


### PR DESCRIPTION
Removing reference to the 1% and the old blog post, as well as referencing "strengthening Ethereum's consensus". Instead adding DOE narrative so this page is aligned with our other RAF content. 
