### PR TITLE
Disable automatic PR workflows

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": false,
   "extends": [
     "config:recommended"
   ],

--- a/.github/workflows/dispatch-update.yml
+++ b/.github/workflows/dispatch-update.yml
@@ -1,8 +1,11 @@
 name: Update Docs Version
 
+# Disabled - version updates are done manually
+# on:
+#   repository_dispatch:
+#     types: [update-version]
 on:
-  repository_dispatch:
-    types: [update-version]
+  workflow_dispatch: # Allow manual trigger only
 
 jobs:
   update-docs-version:


### PR DESCRIPTION
## Summary
- Disable Renovate automatic dependency update PRs
- Disable charon repository dispatch version update workflow (changed to manual trigger only via `workflow_dispatch`)

## Reason
Automatic PRs were creating noise and version bump commits were unsigned.