### PR TITLE
fix: enforce semantic commits in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "semanticCommits": "enabled",
   "enabledManagers": [
     "github-actions"
   ],


### PR DESCRIPTION
Renovate v43.104.0 changed its semantic commit auto-detector. Fix: explicitly set `"semanticCommits": "enabled"` instead of relying on auto-detection.