### PR TITLE
Update bug bounty scope: add Obol SDK/APIs, note on alpha subcommand severity

### DIFF
--- a/docs/adv/security/bug-bounty.md
+++ b/docs/adv/security/bug-bounty.md
@@ -24,8 +24,13 @@ Eligible submissions must involve software and services developed by Obol, speci
 
 - Charon the DV Middleware Client
 - Obol DV Launchpad and Public API
+- Obol SDK and APIs
 - Obol Splits Contracts
 - Obol Labs hosted Public Relay Infrastructure
+
+:::note
+Vulnerabilities found in Charon code under the `alpha` subcommand may be down-weighted in severity, as these features are not recommended for production use.
+:::
 
 Submissions related to the following are considered out of scope:
 


### PR DESCRIPTION
## Summary
- Adds **Obol SDK and APIs** to the bug bounty program's in-scope targets
- Adds a note that vulnerabilities in Charon's `alpha` subcommand may be **down-weighted in severity**, as those features are not recommended for production use

## Test plan
- [ ] Verify the Docusaurus `:::note` admonition renders correctly on the bug bounty page
- [ ] Confirm the scope list reads naturally with the new entry